### PR TITLE
fix/5: run build workflow on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 env:
   SPARK_VERSION: '4.0.0'


### PR DESCRIPTION
## Problem

The fork's default branch is \`main\`, but \`.github/workflows/build.yml\` only triggers on \`push\` to \`master\`. Merges to \`main\` get no CI signal. A regression on main can sit unnoticed between the merge and whatever happens to touch master next, which in a fork of an under-trafficked upstream could be never.

## Intuition

CI's job is to tell us the default branch is green. If the default branch isn't in the trigger list, CI is answering a question nobody asked.

\`pull_request\` already fires for any base branch, so open PRs targeting main are fine. The gap is only on merged pushes.

## Implementation

One-line change:

~~~diff
   push:
     branches:
-      - master
+      - main
~~~

\`master\` stays in the repo as a read-only mirror of upstream for rebase purposes, but it no longer drives CI for fork work.

Validating: once this PR merges, the next commit on main fires the workflow; the PR itself runs under the \`pull_request\` trigger that was already in place.

Closes #5.