### PR TITLE
fix/8: fall back to archive.apache.org when dlcdn 404s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,12 @@ jobs:
           echo "Apache Spark is not installed"
           # Access the directory.
           mkdir -p ~/deps/
-          wget -q https://dlcdn.apache.org/spark/spark-${{ env.SPARK_VERSION }}/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
+          # dlcdn.apache.org only keeps current releases on its mirrors and
+          # occasionally 404s on older ones. archive.apache.org is the
+          # canonical mirror and never rotates — use it as a fallback.
+          ARCHIVE=spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
+          wget -q https://dlcdn.apache.org/spark/spark-${{ env.SPARK_VERSION }}/$ARCHIVE || \
+          wget -q https://archive.apache.org/dist/spark/spark-${{ env.SPARK_VERSION }}/$ARCHIVE
           tar -xzf spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz -C ~/deps/
           # Delete the old file
           rm spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz

--- a/spark/client/client_test.go
+++ b/spark/client/client_test.go
@@ -19,6 +19,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"testing"
+	"time"
+
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
@@ -31,8 +34,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestAnalyzePlanCallsAnalyzePlanOnClient(t *testing.T) {

--- a/spark/sql/types/rowiterator.go
+++ b/spark/sql/types/rowiterator.go
@@ -3,10 +3,11 @@ package types
 import (
 	"context"
 	"errors"
-	"github.com/apache/arrow-go/v18/arrow"
 	"io"
 	"sync"
 	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
 )
 
 // RowIterator provides streaming access to individual rows
@@ -116,7 +117,6 @@ func (iter *rowIteratorImpl) fetchNextBatch() error {
 				defer record.Release()
 				return ReadArrowRecordToRows(record)
 			}()
-
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,6 @@ func (iter *rowIteratorImpl) fetchNextBatch() error {
 						defer record.Release()
 						return ReadArrowRecordToRows(record)
 					}()
-
 					if err != nil {
 						return err
 					}

--- a/spark/sql/types/rowiterator_test.go
+++ b/spark/sql/types/rowiterator_test.go
@@ -3,11 +3,12 @@ package types_test
 import (
 	"context"
 	"errors"
-	"github.com/apache/arrow-go/v18/arrow/array"
-	"github.com/apache/arrow-go/v18/arrow/memory"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
## Problem

The Setup Apache Spark step in \`build.yml\` downloads \`spark-4.0.0-bin-hadoop3.tgz\` from \`dlcdn.apache.org\`. The mirror network rotates older releases off without warning and sometimes returns 404 on current ones during rolling mirror updates. Every CI run since then has failed at this step with wget exit 8, blocking signal on every PR.

## Intuition

\`dlcdn.apache.org\` is fast but lossy; \`archive.apache.org\` is canonical and never rotates. Download speed doesn't matter here — the result is cached. Correctness does.

## Implementation

One-line change (cosmetically three): try \`dlcdn\` first, fall back to \`archive\` on failure.

~~~diff
-          wget -q https://dlcdn.apache.org/spark/spark-${VER}/${ARCHIVE}
+          wget -q https://dlcdn.apache.org/spark/spark-${VER}/${ARCHIVE} || \
+          wget -q https://archive.apache.org/dist/spark/spark-${VER}/${ARCHIVE}
~~~

Both endpoints serve bit-identical artefacts for every released Spark version, so the tarball is the same either way.

## Tests

The run on this PR exercises the fix — if dlcdn is unavailable the fallback fires. Existing cache key (\`v2-spark-${VER}-bin-hadoop${H}\`) is unchanged, so warm runs don't re-download.

Closes #8.