### PR TITLE
fix/2: strip DEBUG stdout prints from the ExecutePlan loop

### DIFF
--- a/spark/client/client.go
+++ b/spark/client/client.go
@@ -368,15 +368,6 @@ func (c *ExecutePlanClient) ToTable() (*types.StructType, arrow.Table, error) {
 	c.done = false
 	for {
 		resp, err := c.responseStream.Recv()
-		if err != nil {
-			fmt.Printf("DEBUG: Recv error: %v, is EOF: %v\n", err, errors.Is(err, io.EOF))
-		}
-		if err == nil && resp != nil {
-			fmt.Printf("DEBUG: Received response type: %T\n", resp.ResponseType)
-			if _, ok := resp.ResponseType.(*proto.ExecutePlanResponse_ResultComplete_); ok {
-				fmt.Println("DEBUG: Got ResultComplete!")
-			}
-		}
 		// EOF is received when the last message has been processed and the stream
 		// finished normally.
 		if errors.Is(err, io.EOF) {

--- a/spark/client/client_test.go
+++ b/spark/client/client_test.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -1002,4 +1004,54 @@ func collectRecords(t *testing.T, recordChan <-chan arrow.Record, errorChan <-ch
 			t.Fatal("Test timed out collecting records")
 		}
 	}
+}
+
+// TestExecutePlan_DoesNotWriteToStdout captures process stdout while
+// a complete ExecutePlan round-trip runs and asserts nothing lands
+// on it. The client is a library; stdout belongs to the host. This
+// regression test pins that contract — without it a stray fmt.Print
+// would land silently and downstream services would wake up to
+// protocol chatter in their logs.
+func TestExecutePlan_DoesNotWriteToStdout(t *testing.T) {
+	ctx := context.Background()
+
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = originalStdout })
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		captured <- buf.String()
+	}()
+
+	c := client.NewTestConnectClientFromResponses(mocks.MockSessionId, &mocks.ExecutePlanResponseEOF)
+
+	stream, err := c.ExecutePlan(ctx, mocks.NewSqlCommand("select 1"))
+	require.NoError(t, err)
+
+	recordChan, errorChan, _ := stream.ToRecordBatches(ctx)
+
+	// Drain the stream; we only care about stdout side effects here.
+	timeout := time.After(100 * time.Millisecond)
+loop:
+	for {
+		select {
+		case _, ok := <-recordChan:
+			if !ok {
+				break loop
+			}
+		case <-errorChan:
+		case <-timeout:
+			t.Fatal("drain timed out")
+		}
+	}
+
+	require.NoError(t, w.Close())
+	output := <-captured
+	assert.Empty(t, output,
+		"ExecutePlan wrote to stdout; the client must not produce protocol chatter on the host's stdout")
 }


### PR DESCRIPTION
## Problem

Four \`fmt.Print*\` calls sit in the ExecutePlan response-stream receive loop and print raw protocol chatter on every query:

~~~
DEBUG: Received response type: *generated.ExecutePlanResponse_SqlCommandResult_
DEBUG: Received response type: *generated.ExecutePlanResponse_ExecutionProgress_
DEBUG: Got ResultComplete!
DEBUG: Recv error: EOF, is EOF: true
~~~

For a library, stdout belongs to the host process. Downstream services already have configured logging (zerolog, zap, slog) and none of them want protocol-level detail by default.

## Intuition

These are leftover debug prints from the streaming-reads work. No caller relies on them. Deleting them is the fix; adding a regression test pins the contract so a future stray \`fmt.Print\` doesn't land without anyone noticing.

The \`fmt.Println\` at \`spark/sql/dataframe.go:478\` is a separate beast — it's the default \`ResultCollector\` used by \`DataFrame.Show()\`, which is explicitly user-facing console output. Stays put.

## Implementation

\`spark/client/client.go\`: delete the four \`fmt.Print*\` calls inside the \`for { resp, err := c.responseStream.Recv() }\` loop. Keep every control-flow branch they were wrapping intact — EOF still breaks, RPC errors still propagate.

## Tests

\`TestExecutePlan_DoesNotWriteToStdout\` (new) captures \`os.Stdout\` via a pipe during a complete ExecutePlan round-trip, drains the record/error channels, then asserts the captured buffer is empty. Fails loudly if anyone reintroduces a \`fmt.Print\` in the execute path.

Closes #2.