### PR TITLE
feat/3: expose gRPC transport options on the channel + session builders

### DIFF
--- a/spark/client/channel/channel.go
+++ b/spark/client/channel/channel.go
@@ -77,6 +77,28 @@ type BaseBuilder struct {
 	headers   map[string]string
 	sessionId string
 	userAgent string
+	dialOpts  []grpc.DialOption
+}
+
+// defaultMaxMessageSize is the per-RPC send/receive ceiling we apply
+// when the caller doesn't set one. The server advertises
+// spark.connect.grpc.maxInboundMessageSize at 128 MiB by default and
+// operators routinely raise it to 1 GiB for bulk reads. gRPC's own
+// default is 4 MiB, which silently truncates a single Arrow batch on
+// any non-trivial query and surfaces as opaque ResourceExhausted
+// errors deep inside Collect()/StreamRows(). Matching the upper end
+// of the server's practical range keeps first-run queries from
+// hitting a floor the caller didn't know existed.
+const defaultMaxMessageSize = 1 << 30 // 1 GiB
+
+// WithDialOptions appends gRPC dial options to the channel builder.
+// Callers use this to raise the per-call message ceiling further, set
+// keepalive parameters for long-lived streams, inject interceptors,
+// or swap in a custom dialer. Options are applied after the builder's
+// defaults, so caller-supplied values win.
+func (cb *BaseBuilder) WithDialOptions(opts ...grpc.DialOption) *BaseBuilder {
+	cb.dialOpts = append(cb.dialOpts, opts...)
+	return cb
 }
 
 func (cb *BaseBuilder) Host() string {
@@ -114,6 +136,15 @@ func (cb *BaseBuilder) Build(ctx context.Context) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 
 	opts = append(opts, grpc.WithAuthority(cb.host))
+
+	// Raise the per-call send/receive ceiling off gRPC's 4 MiB default.
+	// Placed before WithDialOptions so caller-supplied DefaultCallOptions
+	// can still override if they want a tighter limit.
+	opts = append(opts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(defaultMaxMessageSize),
+		grpc.MaxCallSendMsgSize(defaultMaxMessageSize),
+	))
+
 	if cb.token == "" {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
@@ -133,6 +164,9 @@ func (cb *BaseBuilder) Build(ctx context.Context) (*grpc.ClientConn, error) {
 		})
 		opts = append(opts, grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: ts}))
 	}
+
+	// Caller overrides come last so they win over the defaults above.
+	opts = append(opts, cb.dialOpts...)
 
 	remote := fmt.Sprintf("%v:%v", cb.host, cb.port)
 	conn, err := grpc.NewClient(remote, opts...)

--- a/spark/client/channel/channel_test.go
+++ b/spark/client/channel/channel_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 
 	"github.com/caldempsey/spark-connect-go/spark/client/channel"
 	"github.com/caldempsey/spark-connect-go/spark/sparkerrors"
@@ -111,4 +112,29 @@ func TestChannelBulder_UserAgent(t *testing.T) {
 	assert.True(t, strings.Contains(cb.UserAgent(), "go/"))
 	assert.True(t, strings.Contains(cb.UserAgent(), "spark/"))
 	assert.True(t, strings.Contains(cb.UserAgent(), "os/"))
+}
+
+// TestChannelBuilder_WithDialOptions_CompilesAndBuilds is a smoke
+// test: the builder accepts caller-supplied grpc.DialOption values,
+// stores them, and a subsequent Build produces a live ClientConn
+// without panicking. We assert the returned conn is non-nil rather
+// than exercising the wire — grpc.NewClient is lazy and doesn't dial
+// until the first RPC, so a stricter assertion would spin up a
+// server here.
+func TestChannelBuilder_WithDialOptions_CompilesAndBuilds(t *testing.T) {
+	cb, err := channel.NewBuilder("sc://localhost")
+	assert.NoError(t, err)
+
+	// Representative knobs: raise the per-call ceiling further than
+	// the builder's own default, and give the connection a keepalive
+	// profile. Neither changes observable behaviour in this unit
+	// test, but both have to survive the builder round-trip.
+	cb.WithDialOptions(
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(2<<30)),
+		grpc.WithUserAgent("dorm-test"),
+	)
+
+	conn, err := cb.Build(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
 }

--- a/spark/sql/sparksession.go
+++ b/spark/sql/sparksession.go
@@ -37,6 +37,7 @@ import (
 	"github.com/caldempsey/spark-connect-go/spark/client/channel"
 	"github.com/caldempsey/spark-connect-go/spark/sparkerrors"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -58,6 +59,7 @@ func NewSessionBuilder() *SparkSessionBuilder {
 type SparkSessionBuilder struct {
 	connectionString string
 	channelBuilder   channel.Builder
+	dialOpts         []grpc.DialOption
 }
 
 // Remote sets the connection string for remote connection
@@ -71,12 +73,26 @@ func (s *SparkSessionBuilder) WithChannelBuilder(cb channel.Builder) *SparkSessi
 	return s
 }
 
+// WithDialOptions appends gRPC dial options that will be applied when
+// the session builds its underlying channel. Useful for raising the
+// per-call message ceiling further, tuning keepalive, or installing
+// interceptors — anything Spark Connect doesn't expose as a server
+// conf. Ignored when WithChannelBuilder was also called; a custom
+// channel owns its own dial options.
+func (s *SparkSessionBuilder) WithDialOptions(opts ...grpc.DialOption) *SparkSessionBuilder {
+	s.dialOpts = append(s.dialOpts, opts...)
+	return s
+}
+
 func (s *SparkSessionBuilder) Build(ctx context.Context) (SparkSession, error) {
 	if s.channelBuilder == nil {
 		cb, err := channel.NewBuilder(s.connectionString)
 		if err != nil {
 			return nil, sparkerrors.WithType(fmt.Errorf(
 				"failed to connect to remote %s: %w", s.connectionString, err), sparkerrors.ConnectionError)
+		}
+		if len(s.dialOpts) > 0 {
+			cb.WithDialOptions(s.dialOpts...)
 		}
 		s.channelBuilder = cb
 	}

--- a/spark/sql/sparksession_test.go
+++ b/spark/sql/sparksession_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	proto "github.com/caldempsey/spark-connect-go/internal/generated"
 	"github.com/caldempsey/spark-connect-go/spark/client"
@@ -190,4 +191,20 @@ func TestWriteResultStreamsArrowResultToCollector(t *testing.T) {
 	vals := rows[1].Values()
 	assert.NoError(t, err)
 	assert.Equal(t, []any{"str2"}, vals)
+}
+
+// TestSessionBuilder_WithDialOptions_Forwarded asserts that
+// caller-supplied grpc.DialOption values are forwarded to the
+// channel builder the session creates. We build against a bogus
+// endpoint and don't dial — grpc.NewClient is lazy and doesn't open
+// a connection until the first RPC, so the interesting surface is
+// that WithDialOptions composes into the builder's state without
+// error.
+func TestSessionBuilder_WithDialOptions_Forwarded(t *testing.T) {
+	ctx := context.Background()
+	_, err := NewSessionBuilder().
+		Remote("sc://localhost").
+		WithDialOptions(grpc.WithUserAgent("dorm-test")).
+		Build(ctx)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Problem

The channel layer hands fixed \`grpc.DialOption\` values to \`grpc.NewClient\` with no way for callers to override them. In practice this caps \`MaxCallRecvMsgSize\` / \`MaxCallSendMsgSize\` at gRPC's 4 MiB default, which is below a single Arrow batch on any non-trivial query. Users hit this as opaque \`ResourceExhausted\` errors deep inside \`Collect()\` or \`StreamRows()\`. Keepalive, interceptors, and custom dialers are equally invisible to callers.

## Intuition

Two moves:

1. Raise the builder's own default ceiling from 4 MiB to 1 GiB so first-run queries don't trip a floor nobody documented. 1 GiB matches the upper end of \`spark.connect.grpc.maxInboundMessageSize\` that operators routinely configure; neither end of the protocol is allocating a GiB per call, it's just a ceiling.
2. Add a \`WithDialOptions(...)\` setter on both \`BaseBuilder\` (channel layer) and \`SparkSessionBuilder\` (high-level entry point) so callers can append anything gRPC accepts — tighter ceilings, keepalive, interceptors.

Caller options are appended after the builder's defaults so a caller-supplied \`MaxCallRecvMsgSize\` wins over the 1 GiB default.

## Implementation

- \`spark/client/channel/channel.go\`
  - Add \`dialOpts []grpc.DialOption\` field on \`BaseBuilder\`.
  - Add \`(cb *BaseBuilder) WithDialOptions(opts ...grpc.DialOption) *BaseBuilder\`.
  - Inside \`Build\`: prepend \`grpc.WithDefaultCallOptions(MaxCallRecvMsgSize/MaxCallSendMsgSize = 1 GiB)\` as a default; append \`cb.dialOpts\` last so callers override.
- \`spark/sql/sparksession.go\`
  - Add \`dialOpts []grpc.DialOption\` field on \`SparkSessionBuilder\`.
  - Add \`(s *SparkSessionBuilder) WithDialOptions(opts ...grpc.DialOption) *SparkSessionBuilder\`.
  - When the session creates its own channel builder, forward dialOpts via \`cb.WithDialOptions(...)\`. When a user supplies a custom channel via \`WithChannelBuilder\`, their builder owns its own dial options.

## Tests

- \`TestChannelBuilder_WithDialOptions_CompilesAndBuilds\` asserts the builder accepts grpc options and produces a non-nil \`ClientConn\`. \`grpc.NewClient\` is lazy so a stricter assertion would need a local server; this is a smoke test.
- \`TestSessionBuilder_WithDialOptions_Forwarded\` does the same at the session layer — the public surface callers actually hold.

Existing channel + session tests unchanged; the 1 GiB default is additive and doesn't change any asserted behaviour.

Closes #3.