### PR TITLE
feat/4: add typed DataFrame[T]

### DIFF
--- a/spark/sql/dataframe_typed.go
+++ b/spark/sql/dataframe_typed.go
@@ -1,0 +1,322 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// DataFrameOf[T] is a typed view on a regular DataFrame. Users
+// parameterise it on a Go struct; Collect decodes rows directly
+// into T instead of handing back []any that callers have to
+// type-assert field by field.
+//
+// Column binding uses struct tags in the same shape sqlx / parquet-go
+// already use:
+//
+//	type User struct {
+//	    ID      string    `spark:"id"`
+//	    Email   string    `spark:"email"`
+//	    Created time.Time `spark:"created_at"`
+//	}
+//
+// Fields without a `spark:"..."` tag are mapped by snake_case'd field
+// name, so a plain Go struct works without any tags at all. Fields
+// tagged `spark:"-"` are skipped. Columns in the DataFrame that
+// don't match any field are ignored — typical of projections
+// narrower than the struct.
+//
+// Schema drift (a struct field that the result's projection doesn't
+// contain) surfaces at the first Collect call as a single error
+// rather than per-row panics.
+//
+// Streaming (iter.Seq2 over T) is intentionally not in v0 — the
+// ExecutePlanClient plumbing wants a dedicated PR so it can ship
+// alongside a proper test matrix. For now, users who need streaming
+// call DataFrame() to drop to the untyped ToRecordSequence path.
+type DataFrameOf[T any] struct {
+	df   DataFrame
+	plan *rowPlan
+}
+
+// SqlTyped runs a SQL query and returns a typed DataFrame over the
+// result. Equivalent to SparkSession.Sql followed by a struct-tag-
+// driven scanner at every row — except the plan is computed once
+// and reused for every Collect call on the returned value.
+func SqlTyped[T any](ctx context.Context, session SparkSession, query string) (*DataFrameOf[T], error) {
+	df, err := session.Sql(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return TypedDataFrame[T](df)
+}
+
+// TypedDataFrame wraps an existing DataFrame in the typed surface.
+// Useful when the caller already holds a DataFrame produced by an
+// operation other than Sql (Read, Table, a chain of transformations).
+// Computes and caches the row plan immediately; a malformed struct
+// surfaces here rather than per-row inside Collect.
+func TypedDataFrame[T any](df DataFrame) (*DataFrameOf[T], error) {
+	var zero T
+	rt := reflect.TypeOf(zero)
+	if rt == nil || rt.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("DataFrameOf[T]: T must be a struct, got %v", rt)
+	}
+	plan, err := buildRowPlan(rt)
+	if err != nil {
+		return nil, err
+	}
+	return &DataFrameOf[T]{df: df, plan: plan}, nil
+}
+
+// DataFrame returns the underlying untyped DataFrame. Escape hatch
+// for operations the typed surface doesn't cover — GroupBy, joins,
+// window functions. Chain freely and call TypedDataFrame again on
+// the result when the output shape is known.
+func (d *DataFrameOf[T]) DataFrame() DataFrame { return d.df }
+
+// Collect materialises every row into a []T. Holds the whole table
+// on the heap for the duration of the call — callers with large
+// result sets should project narrower on the SQL side or drop to
+// the untyped streaming path via DataFrame().
+func (d *DataFrameOf[T]) Collect(ctx context.Context) ([]T, error) {
+	rows, err := d.df.Collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	cols := rows[0].FieldNames()
+	bindings, err := d.plan.bind(cols)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]T, len(rows))
+	for i, r := range rows {
+		if err := decodeRow(d.plan, r.Values(), bindings, &out[i]); err != nil {
+			return nil, fmt.Errorf("DataFrameOf[T].Collect: row %d: %w", i, err)
+		}
+	}
+	return out, nil
+}
+
+// rowPlan caches the reflected structure of T so Collect doesn't
+// reflect on every row. Built once per DataFrameOf[T].
+type rowPlan struct {
+	goType reflect.Type
+	fields []plannedField
+}
+
+type plannedField struct {
+	name  string // column name from tag or snake_case'd field name
+	index []int  // reflect.FieldByIndex path
+	gotyp reflect.Type
+}
+
+// columnBinding maps a result-set column position to the field slot
+// in the plan that should receive it. A column that the struct
+// doesn't describe has planIndex = -1 and is skipped.
+type columnBinding struct {
+	planIndex int
+}
+
+var rowPlanCache sync.Map // reflect.Type -> *rowPlan
+
+func buildRowPlan(rt reflect.Type) (*rowPlan, error) {
+	if cached, ok := rowPlanCache.Load(rt); ok {
+		return cached.(*rowPlan), nil
+	}
+	plan := &rowPlan{goType: rt}
+	if err := walkPlan(rt, nil, plan); err != nil {
+		return nil, err
+	}
+	rowPlanCache.Store(rt, plan)
+	return plan, nil
+}
+
+func walkPlan(rt reflect.Type, parent []int, plan *rowPlan) error {
+	for i := 0; i < rt.NumField(); i++ {
+		sf := rt.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		idx := append(append([]int{}, parent...), i)
+		tag := sf.Tag.Get("spark")
+		if tag == "-" {
+			continue
+		}
+		if sf.Anonymous && sf.Type.Kind() == reflect.Struct && tag == "" {
+			if err := walkPlan(sf.Type, idx, plan); err != nil {
+				return err
+			}
+			continue
+		}
+		name := tag
+		if name == "" {
+			name = snakeCase(sf.Name)
+		}
+		plan.fields = append(plan.fields, plannedField{
+			name:  name,
+			index: idx,
+			gotyp: sf.Type,
+		})
+	}
+	return nil
+}
+
+// bind aligns the plan's fields with a concrete set of result
+// columns. Result columns that don't map to any planned field are
+// tagged planIndex = -1 and dropped at decode time. A planned field
+// that doesn't appear in the columns is a schema-drift error — the
+// SQL changed in a way the struct doesn't describe and we want the
+// caller to know at plan time, not per row.
+func (p *rowPlan) bind(columns []string) ([]columnBinding, error) {
+	byName := make(map[string]int, len(p.fields))
+	for i, f := range p.fields {
+		byName[f.name] = i
+	}
+	bindings := make([]columnBinding, len(columns))
+	seen := make(map[int]bool, len(p.fields))
+	for ci, name := range columns {
+		if idx, ok := byName[name]; ok {
+			bindings[ci] = columnBinding{planIndex: idx}
+			seen[idx] = true
+		} else {
+			bindings[ci] = columnBinding{planIndex: -1}
+		}
+	}
+	var missing []string
+	for i, f := range p.fields {
+		if !seen[i] {
+			missing = append(missing, f.name)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("DataFrameOf[T]: struct field(s) not in result schema: %s",
+			strings.Join(missing, ", "))
+	}
+	return bindings, nil
+}
+
+// decodeRow writes values into *T using the bindings. dest is a
+// pointer to T; we take *T (not T) so the caller can write each
+// element of a pre-allocated []T slice without paying for a
+// reflect.Value per row.
+func decodeRow[T any](plan *rowPlan, values []any, bindings []columnBinding, dest *T) error {
+	dv := reflect.ValueOf(dest).Elem()
+	for ci := 0; ci < len(values) && ci < len(bindings); ci++ {
+		b := bindings[ci]
+		if b.planIndex < 0 {
+			continue
+		}
+		pf := &plan.fields[b.planIndex]
+		target := fieldByIndex(dv, pf.index)
+		if err := assignTypedValue(target, values[ci]); err != nil {
+			return fmt.Errorf("column %d (%s): %w", ci, pf.name, err)
+		}
+	}
+	return nil
+}
+
+func fieldByIndex(v reflect.Value, index []int) reflect.Value {
+	cur := v
+	for _, i := range index {
+		for cur.Kind() == reflect.Ptr {
+			if cur.IsNil() {
+				cur.Set(reflect.New(cur.Type().Elem()))
+			}
+			cur = cur.Elem()
+		}
+		cur = cur.Field(i)
+	}
+	return cur
+}
+
+// assignTypedValue writes src into the reflect field, doing the
+// small set of conversions Spark's row values need — nil → zero for
+// optional fields, arrow.Timestamp → time.Time for TIMESTAMP
+// columns, assignable/convertible for primitives. Anything rarer
+// surfaces as an explicit error so callers can tighten their struct
+// to match.
+//
+// Named with the `Typed` suffix to avoid colliding with the existing
+// assignValue helper in other files.
+func assignTypedValue(dst reflect.Value, src any) error {
+	if src == nil {
+		dst.Set(reflect.Zero(dst.Type()))
+		return nil
+	}
+	dt := dst.Type()
+	isPtr := dt.Kind() == reflect.Ptr
+	innerType := dt
+	if isPtr {
+		innerType = dt.Elem()
+	}
+	if ts, ok := src.(arrow.Timestamp); ok && innerType == reflect.TypeOf(time.Time{}) {
+		setTypedValue(dst, reflect.ValueOf(ts.ToTime(arrow.Microsecond)), isPtr, innerType)
+		return nil
+	}
+	sv := reflect.ValueOf(src)
+	if sv.Type().AssignableTo(innerType) {
+		setTypedValue(dst, sv, isPtr, innerType)
+		return nil
+	}
+	if sv.Type().ConvertibleTo(innerType) {
+		setTypedValue(dst, sv.Convert(innerType), isPtr, innerType)
+		return nil
+	}
+	return fmt.Errorf("cannot assign %T to %v", src, dt)
+}
+
+func setTypedValue(dst, src reflect.Value, isPtr bool, inner reflect.Type) {
+	if isPtr {
+		p := reflect.New(inner)
+		p.Elem().Set(src)
+		dst.Set(p)
+		return
+	}
+	dst.Set(src)
+}
+
+// snakeCase converts a Go field name to its snake_case form. Matches
+// the convention used by sqlx / gorm / jackc so a plain Go struct
+// with no tags lines up with columns that follow standard SQL naming.
+func snakeCase(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			if unicode.IsLower(prev) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+				b.WriteByte('_')
+			}
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}

--- a/spark/sql/dataframe_typed_test.go
+++ b/spark/sql/dataframe_typed_test.go
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type typedUser struct {
+	ID        string    `spark:"id"`
+	Email     string    `spark:"email"`
+	Country   string    // no tag — falls back to snake_case of field name
+	CreatedAt time.Time `spark:"created_at"`
+	Secret    string    `spark:"-"` // skipped
+	ignored   string    //nolint:unused // unexported → skipped
+}
+
+func TestBuildRowPlan_TagsAndSnakeCase(t *testing.T) {
+	plan, err := buildRowPlan(reflect.TypeOf(typedUser{}))
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(plan.fields))
+	for _, f := range plan.fields {
+		names = append(names, f.name)
+	}
+	assert.Equal(t, []string{"id", "email", "country", "created_at"}, names,
+		"tag takes precedence; untagged fields snake_case; `-` and unexported skipped")
+}
+
+func TestBind_MatchesColumns(t *testing.T) {
+	plan, _ := buildRowPlan(reflect.TypeOf(typedUser{}))
+
+	// Columns may arrive in a different order than fields and can
+	// include extras the struct doesn't care about; the binder
+	// should pick the right indices and ignore the stranger.
+	cols := []string{"created_at", "extra_col", "email", "id", "country"}
+	bindings, err := plan.bind(cols)
+	require.NoError(t, err)
+
+	want := []int{3, -1, 1, 0, 2}
+	for i, b := range bindings {
+		assert.Equalf(t, want[i], b.planIndex,
+			"column %q bound to wrong plan index", cols[i])
+	}
+}
+
+func TestBind_SchemaDriftErrorsEarly(t *testing.T) {
+	plan, _ := buildRowPlan(reflect.TypeOf(typedUser{}))
+	// email column missing — the struct wants it, the result doesn't
+	// have it. Bind must surface this, not defer to per-row decode.
+	_, err := plan.bind([]string{"id", "country", "created_at"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "email",
+		"schema-drift error should name the missing column")
+}
+
+func TestDecodeRow_ArrowTimestampToTime(t *testing.T) {
+	plan, _ := buildRowPlan(reflect.TypeOf(typedUser{}))
+	cols := []string{"id", "email", "country", "created_at"}
+	bindings, err := plan.bind(cols)
+	require.NoError(t, err)
+
+	when := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	// arrow.Timestamp is an int64 of microseconds since epoch. Build
+	// one directly so the decode path's Microsecond branch fires.
+	ts := arrow.Timestamp(when.UnixMicro())
+
+	values := []any{"abc", "alice@example.com", "UK", ts}
+
+	var out typedUser
+	require.NoError(t, decodeRow(plan, values, bindings, &out))
+
+	assert.Equal(t, "abc", out.ID)
+	assert.Equal(t, "alice@example.com", out.Email)
+	assert.Equal(t, "UK", out.Country)
+	assert.True(t, out.CreatedAt.Equal(when), "TIMESTAMP micros should round-trip to time.Time")
+}
+
+func TestDecodeRow_AssignableAndConvertible(t *testing.T) {
+	type row struct {
+		N int    `spark:"n"` // assignable from int
+		S string `spark:"s"` // assignable from string
+		F int    `spark:"f"` // float64 → int is convertible
+	}
+	plan, err := buildRowPlan(reflect.TypeOf(row{}))
+	require.NoError(t, err)
+	bindings, err := plan.bind([]string{"n", "s", "f"})
+	require.NoError(t, err)
+
+	var out row
+	require.NoError(t, decodeRow(plan, []any{int(42), "hello", float64(7)}, bindings, &out))
+	assert.Equal(t, 42, out.N)
+	assert.Equal(t, "hello", out.S)
+	assert.Equal(t, 7, out.F)
+}
+
+func TestDecodeRow_NilIsZero(t *testing.T) {
+	type row struct {
+		N int    `spark:"n"`
+		S string `spark:"s"`
+	}
+	plan, _ := buildRowPlan(reflect.TypeOf(row{}))
+	bindings, _ := plan.bind([]string{"n", "s"})
+
+	var out row
+	require.NoError(t, decodeRow(plan, []any{nil, nil}, bindings, &out))
+	assert.Zero(t, out.N)
+	assert.Zero(t, out.S)
+}
+
+func TestTypedDataFrame_RejectsNonStruct(t *testing.T) {
+	// TypedDataFrame is supposed to surface the misuse at construction
+	// time, not at Collect. A map / slice / primitive should fail
+	// clearly with a pointer back at the caller's T.
+	type notAStruct = map[string]string
+	_, err := TypedDataFrame[notAStruct](nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "T must be a struct")
+}
+
+func TestSnakeCase_CommonShapes(t *testing.T) {
+	cases := map[string]string{
+		"ID":          "id",
+		"Email":       "email",
+		"CreatedAt":   "created_at",
+		"HTTPServer":  "http_server",
+		"JSONPayload": "json_payload",
+		"A":           "a",
+		"":            "",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, snakeCase(in), "snakeCase(%q)", in)
+	}
+}


### PR DESCRIPTION
## Problem

The DataFrame surface is untyped end-to-end. Rows come back as \`[]any\`/\`types.Row\`, column access goes through string lookups + runtime assertions, and every consumer writes the same scanner-into-struct loop:

~~~go
df, _ := spark.Sql(ctx, "SELECT id, email FROM users")
rows, _ := df.Collect(ctx)
for _, r := range rows {
    id := r.At(0).(string)
    email := r.At(1).(string)
    _ = User{ID: id, Email: email}
}
~~~

pyspark users get typed rows via dataclasses. Scala users get \`Dataset[T]\`. Go users get runtime asserts, which:

- forces every caller to write a reflection-based scanner
- defers schema mismatches to runtime, usually per row
- makes iteration loops harder to read than the SQL they ran

## Intuition

\`T\` is a Go struct. Each field maps to a column via a tag (or snake_case of the field name). The plan — column-to-field bindings, type conversions — is the same for every row of a given query, so compute it once at plan time and reuse it per row.

Schema drift (a struct field that the result projection doesn't contain) is a programming error, not a data error — surface it at \`Collect\` time with a clear message rather than per-row panics.

Streaming a typed iterator is a separate concern that wants its own PR + test matrix; out of scope here.

## Implementation

\`spark/sql/dataframe_typed.go\`:

- \`DataFrameOf[T any]\` — typed wrapper over \`DataFrame\` with a cached \`*rowPlan\`.
- \`SqlTyped[T](ctx, session, query)\` — runs the query, wraps the result.
- \`TypedDataFrame[T](df)\` — wraps an existing DataFrame (e.g. from \`Read()\`, \`Table()\`, or a transformation chain).
- \`(d *DataFrameOf[T]).Collect(ctx) ([]T, error)\` — materialises all rows.
- \`(d *DataFrameOf[T]).DataFrame()\` — escape hatch back to untyped for ops the typed surface doesn't cover.

Plan cache (\`sync.Map\` keyed on \`reflect.Type\`) means the reflection cost is paid once per struct type across the whole process.

## Tests

Unit tests in \`dataframe_typed_test.go\`:

- Plan build — tag wins, bare fields snake_case, \`-\`/unexported skipped.
- Bind — columns in arbitrary order, extras ignored, missing struct field errors loudly.
- Decode — \`arrow.Timestamp\` → \`time.Time\` via MICROS, assignable + convertible primitives, nil → zero.
- \`TypedDataFrame[notAStruct]\` fails at construction, not at Collect.
- \`snakeCase\` covers common shapes including all-caps acronyms.

All green under \`go test ./spark/sql/... -run 'TestBuildRowPlan_|TestBind_|TestDecodeRow_|TestTypedDataFrame_|TestSnakeCase_'\`.

Integration test against a real Spark Connect server (SELECT → typed Collect, round-trip) lands in a follow-up alongside the \`Stream\` implementation — both want the same harness and it felt cleaner to keep one coherent feature per PR.

Closes #4.