### PR TITLE
docs/13: drop upstream 'not for production' notice from fork README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ This project houses the **experimental** client for [Spark
 Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) for
 [Apache Spark](https://spark.apache.org/) written in [Golang](https://go.dev/).
 
-## Current State of the Project
-
-Currently, the Spark Connect client for Golang is highly experimental and should
-not be used in any production setting. In addition, the PMC of the Apache Spark
-project reserves the right to withdraw and abandon the development of this project
-if it is not sustainable.
-
 ## Getting started
 
 This section explains how to run Spark Connect Go locally.


### PR DESCRIPTION
## Problem

The fork's `README.md` carried the upstream Apache PMC disclaimer verbatim:

> Currently, the Spark Connect client for Golang is highly experimental and should not be used in any production setting. In addition, the PMC of the Apache Spark project reserves the right to withdraw and abandon the development of this project if it is not sustainable.

That paragraph describes the upstream project's posture, not this fork's. The fork is the client a downstream project (`datalakeorm/dorm`) ships against, and carrying the PMC notice was misleading on both provenance (the PMC doesn't own this fork) and intent (the fork is run against real workloads).

## Intuition

Striking the section is the whole fix. The opening paragraph still flags the underlying client surface as `**experimental**`, which is the accurate read — pre-1.0, API may churn — without implying either that the PMC owns the fork or that nobody should run it.

No replacement copy: a fork doesn't need its own disclaimer to exist, and the sibling `datalakeorm/dorm` README is where the "do not run this in production" guidance lives for the ecosystem as a whole.

## Implementation

Delete the `## Current State of the Project` section. Seven-line diff.

## Tests

Documentation-only change; CI build/test unaffected.

Closes #13.