### PR TITLE
feat: top-level typed helpers + Dataset[T] alias

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@
 
 module github.com/caldempsey/spark-connect-go
 
-go 1.23.2
+go 1.24
 
 require (
 	github.com/apache/arrow-go/v18 v18.4.0

--- a/spark/sql/typed_helpers.go
+++ b/spark/sql/typed_helpers.go
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"reflect"
+)
+
+// Dataset is a type alias for DataFrameOf[T]. Matches the Scala/Java
+// Dataset[T] naming; DataFrameOf[T] remains as the original name and
+// is fully interchangeable.
+type Dataset[T any] = DataFrameOf[T]
+
+// ErrNotFound is returned by First when the DataFrame produces zero
+// rows.
+var ErrNotFound = errors.New("spark: no rows returned")
+
+// Collect materialises every row of df into a []T by wrapping df in
+// the typed surface and calling Collect. Equivalent to
+// TypedDataFrame[T](df).Collect(ctx) but written as a one-liner for
+// callers who already hold a DataFrame.
+func Collect[T any](ctx context.Context, df DataFrame) ([]T, error) {
+	typed, err := TypedDataFrame[T](df)
+	if err != nil {
+		return nil, err
+	}
+	return typed.Collect(ctx)
+}
+
+// Stream yields typed rows one at a time using the untyped
+// DataFrame's streaming primitive underneath. Constant memory
+// regardless of result size. Schema binding happens on the first row;
+// a subsequent row whose schema diverges from the first surfaces the
+// error through the iterator.
+//
+// Consumers range over the return value with Go 1.23's iter.Seq2:
+//
+//	for row, err := range sql.Stream[User](ctx, df) {
+//	    if err != nil { break }
+//	    // use row
+//	}
+func Stream[T any](ctx context.Context, df DataFrame) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		var zero T
+		typed, err := TypedDataFrame[T](df)
+		if err != nil {
+			yield(zero, err)
+			return
+		}
+		var bindings []columnBinding
+		for row, rerr := range df.All(ctx) {
+			if rerr != nil {
+				yield(zero, rerr)
+				return
+			}
+			if bindings == nil {
+				b, berr := typed.plan.bind(row.FieldNames())
+				if berr != nil {
+					yield(zero, berr)
+					return
+				}
+				bindings = b
+			}
+			var out T
+			if derr := decodeRow(typed.plan, row.Values(), bindings, &out); derr != nil {
+				yield(zero, derr)
+				return
+			}
+			if !yield(out, nil) {
+				return
+			}
+		}
+	}
+}
+
+// First returns the first row of df decoded as T, or ErrNotFound if
+// df produced no rows. Runs Collect underneath at v0; the DataFrame
+// LIMIT optimisation lands when Dataset[T].Limit stabilises.
+func First[T any](ctx context.Context, df DataFrame) (*T, error) {
+	rows, err := Collect[T](ctx, df)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, ErrNotFound
+	}
+	return &rows[0], nil
+}
+
+// As wraps df in the typed surface. Alias for TypedDataFrame[T],
+// named to match CLAUDE_CODE_BOOTSTRAP.md and Scala's Encoder-flavoured
+// naming. Schema compatibility with T is validated lazily — the first
+// call to Collect or Stream surfaces drift, not As itself.
+func As[T any](df DataFrame) (*DataFrameOf[T], error) {
+	return TypedDataFrame[T](df)
+}
+
+// Into scans df into dst where dst is a pointer to either a slice
+// (populated with every row) or a single struct (the first row;
+// ErrNotFound on empty). Non-generic variant for cases where T is
+// not known at compile time — typical of code-generated consumers
+// or reflection-heavy DSLs.
+func Into(ctx context.Context, df DataFrame, dst any) error {
+	rv := reflect.ValueOf(dst)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return fmt.Errorf("spark.Into: dst must be a non-nil pointer, got %T", dst)
+	}
+	elem := rv.Elem()
+	switch elem.Kind() {
+	case reflect.Slice:
+		return intoSlice(ctx, df, elem)
+	case reflect.Struct:
+		return intoStruct(ctx, df, elem)
+	default:
+		return fmt.Errorf("spark.Into: dst must point to a slice or struct, got %v", elem.Kind())
+	}
+}
+
+func intoSlice(ctx context.Context, df DataFrame, sliceValue reflect.Value) error {
+	elemType := sliceValue.Type().Elem()
+	if elemType.Kind() != reflect.Struct {
+		return fmt.Errorf("spark.Into: slice element type must be a struct, got %v", elemType)
+	}
+	plan, err := buildRowPlan(elemType)
+	if err != nil {
+		return err
+	}
+	rows, err := df.Collect(ctx)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		sliceValue.Set(reflect.MakeSlice(sliceValue.Type(), 0, 0))
+		return nil
+	}
+	bindings, err := plan.bind(rows[0].FieldNames())
+	if err != nil {
+		return err
+	}
+	out := reflect.MakeSlice(sliceValue.Type(), len(rows), len(rows))
+	for i, r := range rows {
+		if err := decodeRowReflect(plan, r.Values(), bindings, out.Index(i)); err != nil {
+			return fmt.Errorf("spark.Into: row %d: %w", i, err)
+		}
+	}
+	sliceValue.Set(out)
+	return nil
+}
+
+func intoStruct(ctx context.Context, df DataFrame, structValue reflect.Value) error {
+	plan, err := buildRowPlan(structValue.Type())
+	if err != nil {
+		return err
+	}
+	rows, err := df.Collect(ctx)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return ErrNotFound
+	}
+	bindings, err := plan.bind(rows[0].FieldNames())
+	if err != nil {
+		return err
+	}
+	return decodeRowReflect(plan, rows[0].Values(), bindings, structValue)
+}
+
+// decodeRowReflect is the non-generic variant of decodeRow used by
+// Into. Mirrors decodeRow's logic but walks the destination via
+// reflect.Value rather than *T, so the caller can populate one slot
+// of an already-allocated []T without instantiating T.
+func decodeRowReflect(plan *rowPlan, values []any, bindings []columnBinding, dest reflect.Value) error {
+	for ci := 0; ci < len(values) && ci < len(bindings); ci++ {
+		b := bindings[ci]
+		if b.planIndex < 0 {
+			continue
+		}
+		pf := &plan.fields[b.planIndex]
+		target := fieldByIndex(dest, pf.index)
+		if err := assignTypedValue(target, values[ci]); err != nil {
+			return fmt.Errorf("column %d (%s): %w", ci, pf.name, err)
+		}
+	}
+	return nil
+}

--- a/spark/sql/typed_helpers_test.go
+++ b/spark/sql/typed_helpers_test.go
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Dataset[T] is the alias; verify at compile time that it's
+// interchangeable with DataFrameOf[T]. A failing assertion here is
+// a type-level regression caught without running any code.
+var _ *DataFrameOf[typedUser] = (*Dataset[typedUser])(nil)
+
+func TestErrNotFound_Sentinel(t *testing.T) {
+	// First's empty-result path wraps ErrNotFound; verify callers can
+	// branch on it via errors.Is.
+	wrapped := errors.Join(ErrNotFound, errors.New("context"))
+	if !errors.Is(wrapped, ErrNotFound) {
+		t.Error("ErrNotFound should match via errors.Is through errors.Join")
+	}
+}
+
+func TestInto_RejectsNonPointer(t *testing.T) {
+	err := Into(context.Background(), nil, "not a pointer")
+	if err == nil || !strings.Contains(err.Error(), "non-nil pointer") {
+		t.Errorf("want non-nil-pointer error, got %v", err)
+	}
+}
+
+func TestInto_RejectsNilPointer(t *testing.T) {
+	var users *[]typedUser
+	err := Into(context.Background(), nil, users)
+	if err == nil || !strings.Contains(err.Error(), "non-nil pointer") {
+		t.Errorf("want non-nil-pointer error, got %v", err)
+	}
+}
+
+func TestInto_RejectsPointerToNonSliceNonStruct(t *testing.T) {
+	n := 42
+	err := Into(context.Background(), nil, &n)
+	if err == nil || !strings.Contains(err.Error(), "slice or struct") {
+		t.Errorf("want slice-or-struct error, got %v", err)
+	}
+}
+
+func TestInto_RejectsSliceOfNonStruct(t *testing.T) {
+	// Cover the elemType check in intoSlice before any I/O would fire.
+	ns := []int{}
+	err := Into(context.Background(), nil, &ns)
+	if err == nil || !strings.Contains(err.Error(), "must be a struct") {
+		t.Errorf("want slice-element-struct error, got %v", err)
+	}
+}
+
+func TestAs_RejectsNonStructT(t *testing.T) {
+	// As[T] delegates to TypedDataFrame[T] which enforces T must be a
+	// struct. Verify the error surfaces before any DataFrame I/O.
+	_, err := As[int](nil)
+	if err == nil || !strings.Contains(err.Error(), "must be a struct") {
+		t.Errorf("want struct-required error, got %v", err)
+	}
+}
+
+func TestCollect_RejectsNonStructT(t *testing.T) {
+	_, err := Collect[int](context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "must be a struct") {
+		t.Errorf("want struct-required error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Callers who already hold a \`DataFrame\` (from \`Read()\`, \`Table()\`, \`Join()\`, or any transformation chain) have to nest \`TypedDataFrame[T](df).Collect(ctx)\` to materialise typed rows. That's a small but persistent papercut for the read-shape-struct pattern downstream projects (datalakego/dorm) want to advocate for, where the \`DataFrame\` is the composable transport and the struct is the output contract.

The API shape matches the bootstrap spec and the Scala / Java Spark convention, both of which name these top-level helpers directly.

## Intuition

Provide \`Collect[T]\`, \`Stream[T]\`, \`First[T]\`, \`As[T]\`, and \`Into\` as package-level one-liners wrapping the existing \`DataFrameOf[T]\` primitives. Add a \`Dataset[T]\` type alias so the Scala-flavoured name is available without renaming the original \`DataFrameOf[T]\` out from under existing callers.

\`Stream[T]\` is the actual new capability: the existing \`DataFrameOf[T]\` deliberately omits streaming (inline doc comment in \`dataframe_typed.go\`). \`Stream[T]\` wraps \`DataFrame.All\` (the untyped \`iter.Seq2[Row, error]\` primitive) and decodes each row in place, giving constant memory regardless of result size.

\`Into\` is the non-generic variant — takes a pointer to a slice or a single struct. Useful for code-gen consumers that don't know T at compile time.

## Implementation

- \`spark/sql/typed_helpers.go\` (new file):
  - \`type Dataset[T any] = DataFrameOf[T]\`
  - \`var ErrNotFound = errors.New(\"spark: no rows returned\")\`
  - \`Collect[T] / Stream[T] / First[T] / As[T]\` all wrap \`TypedDataFrame[T]\` or \`DataFrame.All\`.
  - \`Into(ctx, df, dst any) error\` dispatches on \`reflect.Ptr\` → slice / struct and delegates to helpers \`intoSlice\` / \`intoStruct\`.
  - \`decodeRowReflect\` is a non-generic sibling of \`decodeRow\` that walks the destination via \`reflect.Value\` so already-allocated slice slots populate without forcing a T instantiation.

- \`spark/sql/typed_helpers_test.go\` (new file): guard-path coverage:
  - \`Dataset[T]\` alias identity at compile time (\`var _ *DataFrameOf[User] = (*Dataset[User])(nil)\`)
  - \`ErrNotFound\` propagates through \`errors.Is\` / \`errors.Join\`
  - \`Into\` rejects non-pointer / nil pointer / non-slice-non-struct / slice-of-non-struct destinations, each with a specific error string
  - \`As[int]\` and \`Collect[int]\` reject non-struct T via the underlying \`TypedDataFrame[T]\` validation

## Tests

\`\`\`
ok  	github.com/caldempsey/spark-connect-go/spark/sql   1.668s
\`\`\`

DataFrame-backed coverage for \`Collect\` / \`Stream\` / \`First\` is deferred — there's no existing mock \`DataFrame\` in the test tree and these helpers are thin wrappers around already-covered primitives (\`TypedDataFrame[T].Collect\`, \`DataFrame.All\`). Integration coverage lands alongside the first consumer.