### PR TITLE
feat: Dataset[T].Where / Limit / OrderBy / First / Stream methods

### DIFF
--- a/spark/sql/dataframe_typed.go
+++ b/spark/sql/dataframe_typed.go
@@ -58,6 +58,36 @@ import (
 type DataFrameOf[T any] struct {
 	df   DataFrame
 	plan *rowPlan
+	ops  []datasetOp // lazy Where/Limit/OrderBy transforms; applied on materialise
+}
+
+// datasetOp is a pending transform on the underlying DataFrame. Ops
+// are queued by the chainable Where/Limit/OrderBy methods and applied
+// at Collect/Stream/First time so the fluent builder stays ctx-free.
+type datasetOp func(ctx context.Context, df DataFrame) (DataFrame, error)
+
+// resolveDataFrame applies every queued op in declaration order and
+// returns the final DataFrame. Used by Collect/Stream/First to get a
+// materialisable handle.
+func (d *DataFrameOf[T]) resolveDataFrame(ctx context.Context) (DataFrame, error) {
+	df := d.df
+	for _, op := range d.ops {
+		next, err := op(ctx, df)
+		if err != nil {
+			return nil, err
+		}
+		df = next
+	}
+	return df, nil
+}
+
+// clone returns a shallow copy of d with a freshly allocated ops
+// slice so that chained operations don't share state with the parent.
+// Chainable methods return the clone.
+func (d *DataFrameOf[T]) clone() *DataFrameOf[T] {
+	cp := *d
+	cp.ops = append([]datasetOp(nil), d.ops...)
+	return &cp
 }
 
 // SqlTyped runs a SQL query and returns a typed DataFrame over the
@@ -101,7 +131,11 @@ func (d *DataFrameOf[T]) DataFrame() DataFrame { return d.df }
 // result sets should project narrower on the SQL side or drop to
 // the untyped streaming path via DataFrame().
 func (d *DataFrameOf[T]) Collect(ctx context.Context) ([]T, error) {
-	rows, err := d.df.Collect(ctx)
+	df, err := d.resolveDataFrame(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := df.Collect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/spark/sql/dataset_methods.go
+++ b/spark/sql/dataset_methods.go
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"iter"
+
+	"github.com/datalakego/spark-connect-go/spark/sql/column"
+	"github.com/datalakego/spark-connect-go/spark/sql/functions"
+)
+
+// Where adds a filter predicate. Lazy: the condition is applied to
+// the underlying DataFrame when Collect / Stream / First materialises
+// the Dataset. Chainable — each call narrows the projection further.
+//
+// sqlStr is a Spark SQL fragment (e.g. "country = 'UK'" or
+// "id IN ('a', 'b', 'c')"). args is accepted for API compatibility
+// with dorm.Query's signature but currently ignored — the underlying
+// DataFrame.Where takes a bare string; callers interpolate values
+// with fmt.Sprintf or build the fragment via the functions package.
+func (d *DataFrameOf[T]) Where(sqlStr string, args ...any) *DataFrameOf[T] {
+	_ = args
+	cp := d.clone()
+	cp.ops = append(cp.ops, func(ctx context.Context, df DataFrame) (DataFrame, error) {
+		return df.Where(ctx, sqlStr)
+	})
+	return cp
+}
+
+// Limit caps the number of rows materialised. Chainable; repeated
+// calls each produce their own Limit relation in the underlying plan,
+// and Spark's optimiser collapses them to the minimum.
+func (d *DataFrameOf[T]) Limit(n int) *DataFrameOf[T] {
+	cp := d.clone()
+	cp.ops = append(cp.ops, func(ctx context.Context, df DataFrame) (DataFrame, error) {
+		return df.Limit(ctx, int32(n)), nil
+	})
+	return cp
+}
+
+// OrderBy adds an ascending sort by one or more columns. Callers who
+// need descending order, null-ordering modifiers, or expression-based
+// sort keys drop to DataFrame() and invoke Sort directly with
+// column.Convertible values.
+func (d *DataFrameOf[T]) OrderBy(columns ...string) *DataFrameOf[T] {
+	cp := d.clone()
+	cp.ops = append(cp.ops, func(ctx context.Context, df DataFrame) (DataFrame, error) {
+		cols := make([]column.Convertible, 0, len(columns))
+		for _, name := range columns {
+			cols = append(cols, functions.Col(name))
+		}
+		return df.Sort(ctx, cols...)
+	})
+	return cp
+}
+
+// First returns a pointer to the first row as T. Applies Limit(1)
+// under the hood before materialising. Returns ErrNotFound when the
+// (possibly filtered) DataFrame has zero rows.
+func (d *DataFrameOf[T]) First(ctx context.Context) (*T, error) {
+	rows, err := d.Limit(1).Collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, ErrNotFound
+	}
+	return &rows[0], nil
+}
+
+// Stream yields typed rows one at a time with constant memory,
+// honouring any queued Where / Limit / OrderBy. Uses the untyped
+// DataFrame.All streaming primitive underneath. Consumers range with
+// Go 1.23's iter.Seq2:
+//
+//	for row, err := range ds.Stream(ctx) {
+//	    if err != nil { break }
+//	    // use row
+//	}
+func (d *DataFrameOf[T]) Stream(ctx context.Context) iter.Seq2[T, error] {
+	return func(yield func(T, error) bool) {
+		var zero T
+		df, err := d.resolveDataFrame(ctx)
+		if err != nil {
+			yield(zero, err)
+			return
+		}
+		var bindings []columnBinding
+		for row, rerr := range df.All(ctx) {
+			if rerr != nil {
+				yield(zero, rerr)
+				return
+			}
+			if bindings == nil {
+				b, berr := d.plan.bind(row.FieldNames())
+				if berr != nil {
+					yield(zero, berr)
+					return
+				}
+				bindings = b
+			}
+			var out T
+			if derr := decodeRow(d.plan, row.Values(), bindings, &out); derr != nil {
+				yield(zero, derr)
+				return
+			}
+			if !yield(out, nil) {
+				return
+			}
+		}
+	}
+}

--- a/spark/sql/dataset_methods_test.go
+++ b/spark/sql/dataset_methods_test.go
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// Where / Limit / OrderBy are lazy — they queue an op on the
+// DataFrameOf without touching the underlying DataFrame. Verify the
+// queue state, not the materialised output (the latter requires a
+// Spark Connect endpoint and lives in the integration suite).
+
+func newTestDataset(t *testing.T) *DataFrameOf[typedUser] {
+	t.Helper()
+	plan, err := buildRowPlan(reflect.TypeOf(typedUser{}))
+	if err != nil {
+		t.Fatalf("buildRowPlan: %v", err)
+	}
+	return &DataFrameOf[typedUser]{plan: plan}
+}
+
+func TestDataset_WhereQueuesOp(t *testing.T) {
+	ds := newTestDataset(t).Where("country = 'UK'")
+	if len(ds.ops) != 1 {
+		t.Fatalf("expected 1 op after Where, got %d", len(ds.ops))
+	}
+}
+
+func TestDataset_LimitQueuesOp(t *testing.T) {
+	ds := newTestDataset(t).Limit(10)
+	if len(ds.ops) != 1 {
+		t.Fatalf("expected 1 op after Limit, got %d", len(ds.ops))
+	}
+}
+
+func TestDataset_OrderByQueuesOp(t *testing.T) {
+	ds := newTestDataset(t).OrderBy("created_at", "id")
+	if len(ds.ops) != 1 {
+		t.Fatalf("expected 1 op after OrderBy, got %d", len(ds.ops))
+	}
+}
+
+func TestDataset_ChainableWhereLimitOrderBy(t *testing.T) {
+	ds := newTestDataset(t).
+		Where("country = 'UK'").
+		OrderBy("created_at").
+		Limit(10)
+	if len(ds.ops) != 3 {
+		t.Fatalf("expected 3 ops after chain, got %d", len(ds.ops))
+	}
+}
+
+func TestDataset_CloneIsolatesOps(t *testing.T) {
+	parent := newTestDataset(t).Where("a = 1")
+	child := parent.Where("b = 2")
+	// parent should still have exactly 1 op; child 2.
+	if len(parent.ops) != 1 {
+		t.Errorf("parent mutated: %d ops, want 1", len(parent.ops))
+	}
+	if len(child.ops) != 2 {
+		t.Errorf("child ops: %d, want 2", len(child.ops))
+	}
+}
+
+func TestDataset_ResolveWithNoOpsReturnsUnderlying(t *testing.T) {
+	// A dataset with no queued ops should resolve to its own df field
+	// unchanged. Use a sentinel DataFrame that errors on any method;
+	// resolve must not touch it.
+	var called bool
+	fake := &sentinelDataFrame{mark: &called}
+	plan, _ := buildRowPlan(reflect.TypeOf(typedUser{}))
+	ds := &DataFrameOf[typedUser]{df: fake, plan: plan}
+	got, err := ds.resolveDataFrame(context.Background())
+	if err != nil {
+		t.Fatalf("resolveDataFrame: %v", err)
+	}
+	if got != fake {
+		t.Errorf("expected underlying df returned unchanged")
+	}
+	if called {
+		t.Errorf("no-op resolve should not invoke any DataFrame method")
+	}
+}
+
+// sentinelDataFrame is a fake DataFrame whose only job is to be
+// returned by resolve-with-no-ops. Methods panic or flag a marker —
+// used to prove resolveDataFrame isn't touching the underlying.
+type sentinelDataFrame struct {
+	DataFrame
+	mark *bool
+}


### PR DESCRIPTION
## Problem

`DataFrameOf[T]` exposed only `Collect` and `DataFrame()` — a typed row-materialiser plus the untyped escape hatch. Every read-path refinement (filter, sort, cap) forced callers to drop to the untyped `DataFrame`, lose type info, reapply `TypedDataFrame[T]` at the end. The Scala / Java `Dataset[T]` precedent and the bootstrap spec both advertise a chainable typed surface, and its absence is the biggest user-facing gap in the fork's typed API.

## Intuition

Five methods, all chainable where chainability makes sense:

```go
ds := sparksql.As[User](df).
    Where("country = 'UK'").
    OrderBy("created_at").
    Limit(100)

users, err := ds.Collect(ctx)
first, err := ds.First(ctx)
for u, err := range ds.Stream(ctx) { /* ... */ }
```

Lazy underneath — `Where` / `Limit` / `OrderBy` append a `datasetOp` closure to a queue and return a cloned `DataFrameOf[T]` so a parent chain doesn't leak mutations into a child. `Collect` / `Stream` / `First` apply the queue in declaration order at materialise time. Matches Spark's own lazy evaluation: Where/Limit/OrderBy only build Relation protos, they don't execute anything until the server pulls on the handle.

## Implementation

- `spark/sql/dataset_methods.go` (new):
  - `Where(sqlStr string, args ...any) *DataFrameOf[T]` — queues `DataFrame.Where`; `args` accepted for dorm-shaped compatibility but currently ignored (underlying takes a bare string).
  - `Limit(n int) *DataFrameOf[T]` — queues `DataFrame.Limit(int32(n))`.
  - `OrderBy(columns ...string) *DataFrameOf[T]` — queues `DataFrame.Sort` with `functions.Col` wrapped bare names; ascending only at v0. Descending / null-ordering modifiers drop to `DataFrame() + Sort(...)` directly.
  - `First(ctx) (*T, error)` — `Limit(1).Collect(ctx)`; returns `ErrNotFound` on empty (sentinel from `typed_helpers.go`).
  - `Stream(ctx) iter.Seq2[T, error]` — wraps the untyped `DataFrame.All` streaming primitive, decoding each row via `decodeRow` against the pre-bound plan.

- `spark/sql/dataframe_typed.go`:
  - `DataFrameOf[T]` gains `ops []datasetOp` field.
  - New `resolveDataFrame(ctx)` method walks `ops`, returns the final `DataFrame`.
  - `clone()` shallow-copies and allocates a fresh `ops` slice so chains stay isolated.
  - `Collect` now resolves through `resolveDataFrame` before materialising. No behaviour change for a `DataFrameOf` constructed without chained ops — the resolver is a no-op when `len(ops) == 0`.

## Tests

```
=== RUN   TestDataset_WhereQueuesOp
--- PASS: TestDataset_WhereQueuesOp (0.00s)
=== RUN   TestDataset_LimitQueuesOp
--- PASS: TestDataset_LimitQueuesOp (0.00s)
=== RUN   TestDataset_OrderByQueuesOp
--- PASS: TestDataset_OrderByQueuesOp (0.00s)
=== RUN   TestDataset_ChainableWhereLimitOrderBy
--- PASS: TestDataset_ChainableWhereLimitOrderBy (0.00s)
=== RUN   TestDataset_CloneIsolatesOps
--- PASS: TestDataset_CloneIsolatesOps (0.00s)
=== RUN   TestDataset_ResolveWithNoOpsReturnsUnderlying
--- PASS: TestDataset_ResolveWithNoOpsReturnsUnderlying (0.00s)
```

All previously-green fork tests still pass. Materialisation-level coverage (actually running a chain against a Spark Connect endpoint) is integration scope and lands with the `SPARK_HOME`-gated suite.

Depends on nothing from dorm; consumers get the new surface on the next `go get`.