### PR TITLE
feat: ErrClusterNotReady + IsClusterNotReady + NewClusterNotReady

### DIFF
--- a/spark/sparkerrors/cluster_not_ready.go
+++ b/spark/sparkerrors/cluster_not_ready.go
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sparkerrors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrClusterNotReady is returned when a Spark cluster is in a
+// warm-up state and the RPC is safe to retry after backoff. The
+// canonical case is Databricks clusters returning
+// `[FailedPrecondition]` with `state Pending` during cold start,
+// but the pattern also fires for self-managed clusters whose
+// drivers are still resolving JARs.
+//
+// Wrap the typed ClusterNotReady with %w so errors.Is lookups keep
+// working:
+//
+//	if errors.Is(err, sparkerrors.ErrClusterNotReady) { ... }
+//	if sparkerrors.IsClusterNotReady(err) { ... }
+var ErrClusterNotReady = errors.New("sparkerrors: cluster not ready")
+
+// ClusterNotReady is the typed form of ErrClusterNotReady. Carries
+// enough context (state string, request ID, original cause) for an
+// operator to correlate with server-side logs.
+type ClusterNotReady struct {
+	State     string // e.g. "Pending", "PENDING"
+	RequestID string
+	Message   string
+	Cause     error
+}
+
+func (e *ClusterNotReady) Error() string {
+	return fmt.Sprintf("cluster not ready (state=%s): %s", e.State, e.Message)
+}
+
+func (e *ClusterNotReady) Unwrap() error { return e.Cause }
+
+// Is reports whether target is ErrClusterNotReady. Lets callers
+// branch via errors.Is regardless of whether they hold the sentinel
+// or the typed form.
+func (e *ClusterNotReady) Is(target error) bool { return target == ErrClusterNotReady }
+
+// IsRetryable marks the error as safe to retry after backoff.
+// Callers that drive their own retry loops can branch on this
+// without pulling in the package's retry machinery.
+func (e *ClusterNotReady) IsRetryable() bool { return true }
+
+// IsClusterNotReady is the convenience wrapper around errors.As for
+// the ClusterNotReady type. Returns true whether err is the typed
+// form or wraps the sentinel; either way a caller's retry loop
+// makes the right call.
+func IsClusterNotReady(err error) bool {
+	if err == nil {
+		return false
+	}
+	var typed *ClusterNotReady
+	if errors.As(err, &typed) {
+		return true
+	}
+	return errors.Is(err, ErrClusterNotReady)
+}
+
+// NewClusterNotReady inspects err for the canonical
+// `[FailedPrecondition]` + `state Pending` pattern and returns a
+// typed ClusterNotReady if it matches, else nil. The string-matching
+// looks fragile but is the detection pattern that's held across
+// multiple Databricks runtime versions and is the shape self-managed
+// Spark clusters emit too.
+//
+// Callers typically invoke this in an RPC error path:
+//
+//	resp, err := cli.ExecutePlan(ctx, req)
+//	if cn := sparkerrors.NewClusterNotReady(err); cn != nil {
+//	    // retry with backoff
+//	}
+func NewClusterNotReady(err error) *ClusterNotReady {
+	if err == nil {
+		return nil
+	}
+	errStr := err.Error()
+
+	if !strings.Contains(errStr, "[FailedPrecondition]") ||
+		(!strings.Contains(errStr, "state Pending") &&
+			!strings.Contains(errStr, "state PENDING")) {
+		return nil
+	}
+
+	state := "PENDING"
+	if idx := strings.Index(errStr, "[state="); idx != -1 {
+		endIdx := strings.Index(errStr[idx:], "]")
+		if endIdx != -1 {
+			state = errStr[idx+7 : idx+endIdx]
+		}
+	}
+
+	var requestID string
+	if idx := strings.Index(errStr, "(requestId="); idx != -1 {
+		endIdx := strings.Index(errStr[idx:], ")")
+		if endIdx != -1 {
+			requestID = errStr[idx+11 : idx+endIdx]
+		}
+	}
+
+	return &ClusterNotReady{
+		State:     state,
+		RequestID: requestID,
+		Message:   "The cluster is starting up. Please retry your request in a few moments.",
+		Cause:     err,
+	}
+}

--- a/spark/sparkerrors/cluster_not_ready_test.go
+++ b/spark/sparkerrors/cluster_not_ready_test.go
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sparkerrors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNewClusterNotReady_DetectsCanonicalDatabricksPattern(t *testing.T) {
+	// Shape ported verbatim from production Databricks responses.
+	raw := errors.New(
+		"rpc error: code = FailedPrecondition desc = " +
+			"[FailedPrecondition] cluster with id=0313-xyz is in state Pending " +
+			"[state=PENDING] (requestId=abc-123)",
+	)
+	got := NewClusterNotReady(raw)
+	if got == nil {
+		t.Fatalf("NewClusterNotReady returned nil on canonical Databricks error: %v", raw)
+	}
+	if got.State != "PENDING" {
+		t.Errorf("State = %q, want PENDING", got.State)
+	}
+	if got.RequestID != "abc-123" {
+		t.Errorf("RequestID = %q, want abc-123", got.RequestID)
+	}
+	if got.Cause != raw {
+		t.Errorf("Cause should be the original error unchanged")
+	}
+	if !got.IsRetryable() {
+		t.Errorf("IsRetryable should be true")
+	}
+}
+
+func TestNewClusterNotReady_RejectsUnrelatedErrors(t *testing.T) {
+	cases := []error{
+		nil,
+		errors.New("connection refused"),
+		errors.New("rpc error: code = Internal desc = server error"),
+		errors.New("[FailedPrecondition] lock held"), // no state Pending marker
+	}
+	for _, e := range cases {
+		if got := NewClusterNotReady(e); got != nil {
+			t.Errorf("NewClusterNotReady(%v) = %v, want nil", e, got)
+		}
+	}
+}
+
+func TestIsClusterNotReady_MatchesTypedAndSentinel(t *testing.T) {
+	raw := errors.New(
+		"[FailedPrecondition] state Pending starting up",
+	)
+	typed := NewClusterNotReady(raw)
+	if !IsClusterNotReady(typed) {
+		t.Errorf("IsClusterNotReady on typed ClusterNotReady should be true")
+	}
+	// Wrap the typed error — IsClusterNotReady should still match
+	// because errors.As unwinds wrapping.
+	wrapped := fmt.Errorf("retrying: %w", typed)
+	if !IsClusterNotReady(wrapped) {
+		t.Errorf("IsClusterNotReady on wrapped typed error should be true")
+	}
+	// A bare sentinel wrap also matches for callers that don't
+	// produce the typed struct.
+	sentinelWrap := fmt.Errorf("context: %w", ErrClusterNotReady)
+	if !IsClusterNotReady(sentinelWrap) {
+		t.Errorf("IsClusterNotReady on %%w-wrapped sentinel should be true")
+	}
+}
+
+func TestIsClusterNotReady_FalseOnNilAndUnrelated(t *testing.T) {
+	if IsClusterNotReady(nil) {
+		t.Errorf("IsClusterNotReady(nil) should be false")
+	}
+	if IsClusterNotReady(errors.New("some other error")) {
+		t.Errorf("IsClusterNotReady on unrelated error should be false")
+	}
+}
+
+func TestClusterNotReady_IsMatchesSentinel(t *testing.T) {
+	// errors.Is should match the sentinel through the typed form's
+	// own Is method (tested independently of the convenience
+	// IsClusterNotReady helper).
+	typed := &ClusterNotReady{State: "PENDING"}
+	if !errors.Is(typed, ErrClusterNotReady) {
+		t.Errorf("errors.Is(typed, ErrClusterNotReady) should be true")
+	}
+}
+
+func TestClusterNotReady_UnwrapExposesCause(t *testing.T) {
+	cause := errors.New("underlying grpc error")
+	typed := &ClusterNotReady{Cause: cause}
+	if got := errors.Unwrap(typed); got != cause {
+		t.Errorf("Unwrap returned %v, want %v", got, cause)
+	}
+}


### PR DESCRIPTION
## Problem

Cluster warm-up is a generic Spark Connect concern — any cluster on any platform can sit in a Pending state during cold start. The detection + typed-error pattern was living in `datalakego/dorm`, which meant every other Spark Connect consumer had to either reimplement the matcher or copy dorm's unchanged. Wrong layer.

## Intuition

Move the detection + sentinel up to the fork's `sparkerrors` package where every consumer benefits. Dorm can stop re-exporting it locally and simply forward the `sparkerrors` types.

Retry-loop wiring (the fork's existing `spark/client/retry.go` consumes this) lands in a follow-up PR alongside `OpenSession` + `SessionOption`. This PR just lands the types so anything that wants to inspect errors in its own retry path can do so today.

## Implementation

`spark/sparkerrors/cluster_not_ready.go` (new file in the existing errors package):

```go
var ErrClusterNotReady = errors.New("sparkerrors: cluster not ready")

type ClusterNotReady struct {
    State     string // "Pending" / "PENDING" / ...
    RequestID string
    Message   string
    Cause     error
}

func (e *ClusterNotReady) Error() string
func (e *ClusterNotReady) Unwrap() error
func (e *ClusterNotReady) Is(target error) bool    // matches ErrClusterNotReady
func (e *ClusterNotReady) IsRetryable() bool       // always true

func IsClusterNotReady(err error) bool             // errors.As convenience
func NewClusterNotReady(err error) *ClusterNotReady
```

`NewClusterNotReady` inspects `err.Error()` for the canonical `[FailedPrecondition]` + `state Pending` pattern. The string-matching looks fragile but is the detection pattern that's held across multiple Databricks runtime versions and is the shape self-managed Spark clusters emit too.

## Tests

```
=== RUN   TestNewClusterNotReady_DetectsCanonicalDatabricksPattern
--- PASS
=== RUN   TestNewClusterNotReady_RejectsUnrelatedErrors
--- PASS
=== RUN   TestIsClusterNotReady_MatchesTypedAndSentinel
--- PASS
=== RUN   TestIsClusterNotReady_FalseOnNilAndUnrelated
--- PASS
=== RUN   TestClusterNotReady_IsMatchesSentinel
--- PASS
=== RUN   TestClusterNotReady_UnwrapExposesCause
--- PASS
```

Coverage: canonical pattern detection (State + RequestID extraction; Cause preserved); rejection on nil / unrelated errors / FailedPrecondition-without-state-Pending; `IsClusterNotReady` matches typed + `%w`-wrapped typed + `%w`-wrapped sentinel; `typed.Is(ErrClusterNotReady)` works for `errors.Is` callers; `Unwrap` exposes the original cause.