### PR TITLE
feat: database/sql driver over Spark Connect

### DIFF
--- a/spark/sql/driver/conn.go
+++ b/spark/sql/driver/conn.go
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+
+	sparksql "github.com/datalakego/spark-connect-go/spark/sql"
+)
+
+// conn is the per-logical-connection state database/sql keeps in its
+// pool. Each Conn holds one Spark Connect session; Close stops it.
+//
+// Implements:
+//   - driver.Conn (legacy Prepare / Close / Begin)
+//   - driver.ConnPrepareContext
+//   - driver.ConnBeginTx
+//   - driver.ExecerContext
+//   - driver.QueryerContext
+//   - driver.Pinger (Ping via session round-trip)
+type conn struct {
+	session sparksql.SparkSession
+	cfg     *dsnConfig
+	closed  bool
+}
+
+// Prepare wraps the SQL in a driver.Stmt. Legacy (non-context)
+// variant of PrepareContext. No server-side preparation — Spark
+// Connect doesn't expose a prepare primitive. Each Exec/Query
+// re-sends the statement; v1+ adds a plan cache if latency matters.
+//
+// Implements database/sql/driver.Conn.
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+// PrepareContext is the context-aware Prepare. Implements
+// database/sql/driver.ConnPrepareContext.
+func (c *conn) PrepareContext(_ context.Context, query string) (driver.Stmt, error) {
+	if c.closed {
+		return nil, driver.ErrBadConn
+	}
+	return &stmt{conn: c, query: query}, nil
+}
+
+// Close releases the underlying Spark Connect session. Idempotent.
+// Implements database/sql/driver.Conn.
+func (c *conn) Close() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	if c.session == nil {
+		return nil
+	}
+	return c.session.Stop()
+}
+
+// Begin returns a no-op transaction. Implements
+// database/sql/driver.Conn (legacy; ConnBeginTx below is preferred).
+func (c *conn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+// BeginTx returns a no-op transaction. Lakehouse commit semantics
+// (Iceberg snapshot commits, Delta transaction log appends) happen
+// at the per-statement level inside Spark, not at a SQL-layer Tx
+// boundary. Wrapping statements in a database/sql Tx doesn't buy
+// atomicity for lakehouse writes, so this driver's Tx is a no-op
+// that lets tools (goose, sqlc) that default to transactional
+// execution not break.
+//
+// Implements database/sql/driver.ConnBeginTx.
+func (c *conn) BeginTx(_ context.Context, _ driver.TxOptions) (driver.Tx, error) {
+	if c.closed {
+		return nil, driver.ErrBadConn
+	}
+	return &tx{}, nil
+}
+
+// ExecContext runs a statement that returns no rows. Forwards to
+// the Stmt path so the NumInput-based argument check lives in one
+// place.
+//
+// Implements database/sql/driver.ExecerContext.
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if c.closed {
+		return nil, driver.ErrBadConn
+	}
+	return (&stmt{conn: c, query: query}).ExecContext(ctx, args)
+}
+
+// QueryContext runs a SELECT returning rows. Implements
+// database/sql/driver.QueryerContext.
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if c.closed {
+		return nil, driver.ErrBadConn
+	}
+	return (&stmt{conn: c, query: query}).QueryContext(ctx, args)
+}
+
+// Ping checks the Spark Connect session is alive. Implements
+// database/sql/driver.Pinger.
+func (c *conn) Ping(ctx context.Context) error {
+	if c.closed {
+		return driver.ErrBadConn
+	}
+	_, err := c.session.Sql(ctx, "SELECT 1")
+	return err
+}
+
+// tx is the no-op transaction described on BeginTx.
+type tx struct{}
+
+// Commit succeeds silently. Implements database/sql/driver.Tx.
+func (tx) Commit() error { return nil }
+
+// Rollback returns an error because lakehouse rollback isn't a
+// meaningful concept at the database/sql layer. Callers that expect
+// Rollback to un-apply statements see the error and can choose to
+// handle it; tools that default to rollback-on-error (goose with
+// failing migrations) get a signal that rollback didn't happen.
+// Implements database/sql/driver.Tx.
+func (tx) Rollback() error {
+	return errors.New("spark driver: transactional rollback is not supported; lakehouse commit semantics are per-statement")
+}

--- a/spark/sql/driver/driver.go
+++ b/spark/sql/driver/driver.go
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package driver implements `database/sql`'s driver interfaces over
+// Spark Connect, so every Go tool that speaks `database/sql` — goose,
+// sqlc, pgx consumers, ad-hoc test harnesses, script code — can target
+// a Spark-backed lakehouse without learning the native client API.
+//
+// The package registers itself on import as the driver name "spark":
+//
+//	import (
+//	    "database/sql"
+//	    _ "github.com/datalakego/spark-connect-go/spark/sql/driver"
+//	)
+//
+//	db, err := sql.Open("spark", "sc://localhost:15002?format=iceberg")
+//
+// DSN grammar is the plain Spark Connect URL with optional query
+// parameters:
+//
+//	sc://host:port
+//	sc://host:port?token=<bearer>
+//	sc://host:port?format=iceberg
+//	sc://host:port?format=delta
+//	sc://host:port?token=<bearer>&format=delta
+//
+// The `format` parameter is consumed by downstream tools (such as
+// goose-spark) that need to emit format-specific DDL; the driver
+// itself doesn't interpret it.
+//
+// v0 scope: sufficient for goose to create its version table, insert
+// applied-migration rows, and select them back. Specifically:
+//
+//   - Exec / Query against a Spark Connect endpoint via session.Sql.
+//   - No statement preparation (every call is `NumInput() == 0`;
+//     callers that pass arguments get an error so SQL injection
+//     isn't possible through this driver, and migrations author their
+//     own literal SQL anyway).
+//   - No-op transactions — Begin / Commit succeed silently, Rollback
+//     warns but does not error. Lakehouse commit semantics live in
+//     Iceberg / Delta at the per-statement level; wrapping statements
+//     in a `database/sql` Tx doesn't buy atomicity here. Documented
+//     in the package comment so a caller who expects real transaction
+//     semantics isn't surprised.
+//
+// v1+ adds: parameter binding via the Spark Connect parameterised-
+// query proto, prepared-statement caching, catalog introspection for
+// row metadata (column names + types) in the Rows wrapper.
+package driver
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+
+	sparksql "github.com/datalakego/spark-connect-go/spark/sql"
+)
+
+// init registers the driver under the name "spark". Consumers that
+// only want the typed DataFrame surface don't have to import this
+// package; consumers that use database/sql do.
+func init() {
+	sql.Register("spark", &sparkDriver{})
+}
+
+// sparkDriver is the database/sql.Driver implementation. Satisfies
+// both the legacy Driver interface (Open) and the modern
+// DriverContext interface (OpenConnector).
+type sparkDriver struct{}
+
+// Open opens a new connection using the given DSN. Implements
+// database/sql/driver.Driver.
+//
+// database/sql calls Open for every new connection the pool wants.
+// Keeping this lightweight — parse the DSN, return a Connector,
+// defer actual session construction to Connect — matches how the
+// standard library's pool expects drivers to behave.
+func (d *sparkDriver) Open(dsn string) (driver.Conn, error) {
+	c, err := d.OpenConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return c.Connect(context.Background())
+}
+
+// OpenConnector returns a Connector ready to produce Conns.
+// Implements database/sql/driver.DriverContext.
+func (d *sparkDriver) OpenConnector(dsn string) (driver.Connector, error) {
+	cfg, err := parseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &connector{driver: d, cfg: cfg}, nil
+}
+
+// connector wraps a parsed DSN and produces Conns on demand.
+type connector struct {
+	driver *sparkDriver
+	cfg    *dsnConfig
+}
+
+// Connect opens a Spark Connect session and returns a driver.Conn
+// wrapping it. Implements database/sql/driver.Connector.
+func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
+	session, err := sparksql.NewSessionBuilder().Remote(c.cfg.sparkDSN).Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &conn{session: session, cfg: c.cfg}, nil
+}
+
+// Driver returns the owning driver. Implements
+// database/sql/driver.Connector.
+func (c *connector) Driver() driver.Driver { return c.driver }

--- a/spark/sql/driver/driver_test.go
+++ b/spark/sql/driver/driver_test.go
@@ -1,0 +1,262 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/datalakego/spark-connect-go/spark/sql/types"
+)
+
+// --- DSN parsing ---------------------------------------------------
+
+func TestParseDSN_AcceptsPlainSc(t *testing.T) {
+	cfg, err := parseDSN("sc://localhost:15002")
+	if err != nil {
+		t.Fatalf("parseDSN: %v", err)
+	}
+	if cfg.sparkDSN != "sc://localhost:15002" {
+		t.Errorf("sparkDSN = %q", cfg.sparkDSN)
+	}
+	if cfg.format != "" {
+		t.Errorf("format = %q, want empty", cfg.format)
+	}
+}
+
+func TestParseDSN_ParsesFormatParameter(t *testing.T) {
+	cfg, err := parseDSN("sc://localhost:15002?format=iceberg")
+	if err != nil {
+		t.Fatalf("parseDSN: %v", err)
+	}
+	if cfg.format != "iceberg" {
+		t.Errorf("format = %q, want iceberg", cfg.format)
+	}
+}
+
+func TestParseDSN_NormalisesFormatCase(t *testing.T) {
+	cfg, err := parseDSN("sc://localhost:15002?format=DELTA")
+	if err != nil {
+		t.Fatalf("parseDSN: %v", err)
+	}
+	if cfg.format != "delta" {
+		t.Errorf("format = %q, want delta (lowercased)", cfg.format)
+	}
+}
+
+func TestParseDSN_RejectsUnknownFormat(t *testing.T) {
+	_, err := parseDSN("sc://localhost:15002?format=duckdb")
+	if err == nil || !strings.Contains(err.Error(), "unsupported format") {
+		t.Errorf("err = %v, want unsupported-format error", err)
+	}
+}
+
+func TestParseDSN_RejectsMissingSchemePrefix(t *testing.T) {
+	_, err := parseDSN("localhost:15002")
+	if err == nil || !strings.Contains(err.Error(), "sc://") {
+		t.Errorf("err = %v, want sc:// required", err)
+	}
+}
+
+func TestParseDSN_RejectsEmpty(t *testing.T) {
+	_, err := parseDSN("")
+	if err == nil || !strings.Contains(err.Error(), "DSN is required") {
+		t.Errorf("err = %v, want DSN-required error", err)
+	}
+}
+
+func TestParseDSN_PreservesTokenInSparkDSN(t *testing.T) {
+	// The token parameter is meaningful to the downstream session
+	// builder; the driver itself doesn't interpret it but must not
+	// strip it from the DSN forwarded to NewSessionBuilder().Remote.
+	cfg, err := parseDSN("sc://host:15002?token=secret&format=iceberg")
+	if err != nil {
+		t.Fatalf("parseDSN: %v", err)
+	}
+	if !strings.Contains(cfg.sparkDSN, "token=secret") {
+		t.Errorf("sparkDSN should carry token unchanged; got %q", cfg.sparkDSN)
+	}
+}
+
+// --- sql.Register side-effect ---------------------------------------
+
+func TestDriver_RegistersAsSparkOnImport(t *testing.T) {
+	// Importing this package (the test binary already does) triggers
+	// init() which calls sql.Register("spark", ...). Verify the
+	// driver list contains "spark".
+	found := false
+	for _, name := range sql.Drivers() {
+		if name == "spark" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("driver list = %v; expected to contain \"spark\"", sql.Drivers())
+	}
+}
+
+func TestDriver_OpenConnectorInvalidDSN(t *testing.T) {
+	_, err := (&sparkDriver{}).OpenConnector("bogus://nope")
+	if err == nil {
+		t.Error("OpenConnector should reject non-sc:// DSN")
+	}
+}
+
+// --- stmt argument rejection ---------------------------------------
+//
+// v0 doesn't implement parameter binding. Callers that pass args
+// should see the errArgsUnsupported sentinel before any server call
+// fires.
+
+func TestStmt_ExecContextRejectsArgs(t *testing.T) {
+	s := &stmt{conn: &conn{}, query: "SELECT 1"}
+	_, err := s.ExecContext(context.Background(), []driver.NamedValue{
+		{Ordinal: 1, Value: 42},
+	})
+	if err == nil || !errors.Is(err, errArgsUnsupported) {
+		t.Errorf("ExecContext with args err = %v, want errArgsUnsupported", err)
+	}
+}
+
+func TestStmt_QueryContextRejectsArgs(t *testing.T) {
+	s := &stmt{conn: &conn{}, query: "SELECT 1"}
+	_, err := s.QueryContext(context.Background(), []driver.NamedValue{
+		{Ordinal: 1, Value: "x"},
+	})
+	if err == nil || !errors.Is(err, errArgsUnsupported) {
+		t.Errorf("QueryContext with args err = %v, want errArgsUnsupported", err)
+	}
+}
+
+// --- Rows wrapper --------------------------------------------------
+
+// rowFake is a minimal types.Row satisfying every method the
+// interface declares. Only FieldNames + Values + Len + At get
+// exercised from rows.go; the rest are required by the interface
+// shape.
+type rowFake struct {
+	names []string
+	vals  []any
+}
+
+func (r rowFake) FieldNames() []string           { return r.names }
+func (r rowFake) Values() []any                  { return r.vals }
+func (r rowFake) Len() int                       { return len(r.vals) }
+func (r rowFake) At(i int) any {
+	if i < 0 || i >= len(r.vals) {
+		return nil
+	}
+	return r.vals[i]
+}
+func (r rowFake) Value(name string) any {
+	for i, n := range r.names {
+		if n == name {
+			return r.vals[i]
+		}
+	}
+	return nil
+}
+func (r rowFake) ToJsonString() (string, error) { return "", nil }
+
+func TestRows_ColumnsReportsFieldNamesFromFirstRow(t *testing.T) {
+	fakes := []types.Row{
+		rowFake{names: []string{"id", "name"}, vals: []any{int64(1), "alice"}},
+		rowFake{names: []string{"id", "name"}, vals: []any{int64(2), "bob"}},
+	}
+	r := newRows(fakes)
+	got := r.Columns()
+	if len(got) != 2 || got[0] != "id" || got[1] != "name" {
+		t.Errorf("Columns = %v, want [id name]", got)
+	}
+}
+
+func TestRows_ColumnsEmptyOnEmptyResult(t *testing.T) {
+	r := newRows(nil)
+	if len(r.Columns()) != 0 {
+		t.Errorf("Columns = %v on empty result, want []", r.Columns())
+	}
+}
+
+func TestRows_NextWalksResultAndStopsOnEOF(t *testing.T) {
+	fakes := []types.Row{
+		rowFake{names: []string{"id", "name"}, vals: []any{int64(1), "alice"}},
+		rowFake{names: []string{"id", "name"}, vals: []any{int64(2), "bob"}},
+	}
+	r := newRows(fakes)
+	dest := make([]driver.Value, 2)
+
+	if err := r.Next(dest); err != nil {
+		t.Fatalf("Next row 1: %v", err)
+	}
+	if dest[0].(int64) != 1 || dest[1].(string) != "alice" {
+		t.Errorf("row 1 = %v, want [1 alice]", dest)
+	}
+
+	if err := r.Next(dest); err != nil {
+		t.Fatalf("Next row 2: %v", err)
+	}
+	if dest[0].(int64) != 2 || dest[1].(string) != "bob" {
+		t.Errorf("row 2 = %v, want [2 bob]", dest)
+	}
+
+	if err := r.Next(dest); err != io.EOF {
+		t.Errorf("Next past end = %v, want io.EOF", err)
+	}
+}
+
+// --- no-op transaction --------------------------------------------
+
+func TestTx_CommitIsNoop(t *testing.T) {
+	var transaction tx
+	if err := transaction.Commit(); err != nil {
+		t.Errorf("Commit err = %v, want nil", err)
+	}
+}
+
+func TestTx_RollbackErrors(t *testing.T) {
+	var transaction tx
+	err := transaction.Rollback()
+	if err == nil || !strings.Contains(err.Error(), "rollback is not supported") {
+		t.Errorf("Rollback err = %v, want rollback-not-supported error", err)
+	}
+}
+
+// --- result --------------------------------------------------------
+
+func TestResult_RowsAffectedReturnsUnknown(t *testing.T) {
+	r := result{}
+	n, err := r.RowsAffected()
+	if err != nil {
+		t.Errorf("RowsAffected err = %v, want nil", err)
+	}
+	if n != -1 {
+		t.Errorf("RowsAffected = %d, want -1 (unknown)", n)
+	}
+}
+
+func TestResult_LastInsertIdErrors(t *testing.T) {
+	r := result{}
+	_, err := r.LastInsertId()
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("LastInsertId err = %v, want not-supported error", err)
+	}
+}

--- a/spark/sql/driver/driver_test.go
+++ b/spark/sql/driver/driver_test.go
@@ -158,15 +158,16 @@ type rowFake struct {
 	vals  []any
 }
 
-func (r rowFake) FieldNames() []string           { return r.names }
-func (r rowFake) Values() []any                  { return r.vals }
-func (r rowFake) Len() int                       { return len(r.vals) }
+func (r rowFake) FieldNames() []string { return r.names }
+func (r rowFake) Values() []any        { return r.vals }
+func (r rowFake) Len() int             { return len(r.vals) }
 func (r rowFake) At(i int) any {
 	if i < 0 || i >= len(r.vals) {
 		return nil
 	}
 	return r.vals[i]
 }
+
 func (r rowFake) Value(name string) any {
 	for i, n := range r.names {
 		if n == name {

--- a/spark/sql/driver/dsn.go
+++ b/spark/sql/driver/dsn.go
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// dsnConfig is the parsed DSN. Kept minimal — the Spark Connect
+// session builder wants the original URL verbatim, so the config
+// mostly exists to surface query-parameter knobs (format, token)
+// that downstream tools want to read without re-parsing the DSN.
+type dsnConfig struct {
+	// sparkDSN is what gets passed to NewSessionBuilder().Remote(...).
+	// Includes any `?token=` fragment if present.
+	sparkDSN string
+
+	// format is the value of the `format` query parameter ("iceberg"
+	// / "delta" / empty). Driver ignores it; consumers that need
+	// dialect-aware DDL read it via the exported Connector.Format()
+	// accessor.
+	format string
+}
+
+// parseDSN accepts the sc:// Spark Connect URL form with optional
+// query parameters. Returns an error for malformed input.
+//
+// Recognised query parameters:
+//
+//   - token: bearer token forwarded to the Spark Connect server in
+//     the Authorization header. Preserved in sparkDSN verbatim so
+//     the session builder picks it up.
+//   - format: lakehouse table format ("iceberg" | "delta"). Driver-
+//     layer passthrough; used by consumers like goose-spark to pick
+//     a dialect-appropriate CREATE TABLE.
+//
+// Unrecognised parameters are ignored (preserved in the DSN as-is)
+// so the driver doesn't fight with future Spark Connect flags.
+func parseDSN(dsn string) (*dsnConfig, error) {
+	if dsn == "" {
+		return nil, errors.New("spark driver: DSN is required")
+	}
+	if !strings.HasPrefix(dsn, "sc://") {
+		return nil, fmt.Errorf("spark driver: DSN must start with sc://, got %q", dsn)
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("spark driver: parse DSN: %w", err)
+	}
+
+	cfg := &dsnConfig{
+		sparkDSN: dsn,
+		format:   strings.ToLower(u.Query().Get("format")),
+	}
+	if cfg.format != "" && cfg.format != "iceberg" && cfg.format != "delta" {
+		return nil, fmt.Errorf(
+			"spark driver: unsupported format %q; expected iceberg or delta", cfg.format)
+	}
+	return cfg, nil
+}

--- a/spark/sql/driver/result.go
+++ b/spark/sql/driver/result.go
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import "errors"
+
+// result is the driver.Result returned by every Exec / ExecContext.
+// Spark Connect's session.Sql doesn't surface a row-count the way
+// Postgres' CommandComplete message does, so we return -1 per the
+// driver.Result docs: "RowsAffected returns the number of rows
+// affected by an update, insert, or delete. Not every database or
+// database driver may support this."
+type result struct{}
+
+// LastInsertId is not supported — lakehouse tables don't have
+// auto-increment semantics. Returns an error so callers that reach
+// for it see the intent clearly rather than getting a misleading
+// zero.
+func (result) LastInsertId() (int64, error) {
+	return 0, errors.New("spark driver: LastInsertId is not supported; lakehouse tables have no auto-increment sequence")
+}
+
+// RowsAffected returns -1 to signal "unknown." Matches the
+// convention several other drivers (notably snowflake, clickhouse)
+// follow when the underlying engine doesn't emit the metric.
+func (result) RowsAffected() (int64, error) {
+	return -1, nil
+}

--- a/spark/sql/driver/rows.go
+++ b/spark/sql/driver/rows.go
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"database/sql/driver"
+	"io"
+
+	"github.com/datalakego/spark-connect-go/spark/sql/types"
+)
+
+// rows wraps a materialised slice of sparksql types.Row values so
+// they satisfy database/sql/driver.Rows. The SELECT path in stmt.go
+// collects a DataFrame first and hands the result here — fine for
+// the small reads goose makes against the version table; larger
+// scans should bypass the database/sql driver and use the native
+// DataFrame / iter.Seq2 path instead.
+type rows struct {
+	rows  []types.Row
+	cols  []string
+	index int
+}
+
+// newRows builds a Rows handle from a slice of sparksql rows.
+// Columns are read from the first row's FieldNames; if the slice
+// is empty, the column list is empty and Next immediately reports
+// io.EOF.
+func newRows(collected []types.Row) *rows {
+	var cols []string
+	if len(collected) > 0 {
+		cols = collected[0].FieldNames()
+	}
+	return &rows{rows: collected, cols: cols}
+}
+
+// Columns returns the column names. Implements
+// database/sql/driver.Rows.
+func (r *rows) Columns() []string { return r.cols }
+
+// Close releases any driver-held resources. The slice is already
+// fully materialised; this is a no-op.
+// Implements database/sql/driver.Rows.
+func (r *rows) Close() error { return nil }
+
+// Next advances to the next row and writes its values into dest.
+// Returns io.EOF when the slice is exhausted. Implements
+// database/sql/driver.Rows.
+func (r *rows) Next(dest []driver.Value) error {
+	if r.index >= len(r.rows) {
+		return io.EOF
+	}
+	values := r.rows[r.index].Values()
+	for i := range dest {
+		if i >= len(values) {
+			dest[i] = nil
+			continue
+		}
+		dest[i] = values[i]
+	}
+	r.index++
+	return nil
+}

--- a/spark/sql/driver/stmt.go
+++ b/spark/sql/driver/stmt.go
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+)
+
+// stmt wraps one query string against a conn. The driver doesn't
+// cache a prepared plan on the server; every Exec/Query re-sends
+// the statement. Works for goose's load (dozens of statements per
+// migration run) and keeps the implementation simple; v1+ adds a
+// server-side plan cache if latency-sensitive callers appear.
+//
+// Implements:
+//   - driver.Stmt (legacy Close / NumInput / Exec / Query)
+//   - driver.StmtExecContext
+//   - driver.StmtQueryContext
+type stmt struct {
+	conn  *conn
+	query string
+}
+
+// Close is a no-op; the statement holds no server-side state.
+// Implements database/sql/driver.Stmt.
+func (*stmt) Close() error { return nil }
+
+// NumInput reports the number of placeholders this statement
+// expects. v0 doesn't support parameter binding, so we return 0
+// and reject non-empty arg slices in ExecContext / QueryContext.
+// goose's generated SQL (CreateVersionTable / InsertVersion) and
+// hand-authored migration files don't use placeholders, so this
+// limitation isn't felt in practice.
+//
+// Implements database/sql/driver.Stmt.
+func (*stmt) NumInput() int { return 0 }
+
+// Exec is the legacy (non-context) Exec entry. Implements
+// database/sql/driver.Stmt.
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	named := make([]driver.NamedValue, len(args))
+	for i, v := range args {
+		named[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return s.ExecContext(context.Background(), named)
+}
+
+// Query is the legacy (non-context) Query entry. Implements
+// database/sql/driver.Stmt.
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	named := make([]driver.NamedValue, len(args))
+	for i, v := range args {
+		named[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return s.QueryContext(context.Background(), named)
+}
+
+// ExecContext runs the statement and discards rows. Returns a
+// Result with RowsAffected=-1 because Spark Connect doesn't surface
+// that metric reliably at the session.Sql layer. database/sql
+// allows -1 per the driver.Result docs.
+//
+// Implements database/sql/driver.StmtExecContext.
+func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	if len(args) > 0 {
+		return nil, errArgsUnsupported
+	}
+	_, err := s.conn.session.Sql(ctx, s.query)
+	if err != nil {
+		return nil, err
+	}
+	return result{}, nil
+}
+
+// QueryContext runs the statement and returns rows. The underlying
+// DataFrame is materialised via Collect and walked by the Rows
+// wrapper. For small result sets (the version-table SELECTs goose
+// fires) this is right-sized; large result sets should bypass the
+// driver and use the native DataFrame / iter.Seq2 path directly.
+//
+// Implements database/sql/driver.StmtQueryContext.
+func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	if len(args) > 0 {
+		return nil, errArgsUnsupported
+	}
+	df, err := s.conn.session.Sql(ctx, s.query)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := df.Collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return newRows(rows), nil
+}
+
+// errArgsUnsupported is the v0 signal that parameter binding isn't
+// implemented. Sentinel so callers can errors.Is on it.
+var errArgsUnsupported = errors.New(
+	"spark driver: parameter binding is not supported in v0; interpolate values into the SQL string or upgrade when v1 ships",
+)


### PR DESCRIPTION
## Problem

The fork ships an untyped `DataFrame` API and a typed `Dataset[T]` wrapper. Neither speaks `database/sql`. Every Go tool that targets a relational database through `database/sql` (goose, sqlc, pgx consumers, any `*sql.DB`-based harness) is locked out of lakehouse endpoints — users have to learn the native client API to use Spark Connect.

The migration story (authoring via `lakeorm`, executing via a forked `goose` — see `lakeorm/PLAN.md`) depends on goose being able to speak to Spark Connect through `sql.Open`. Without a `database/sql` driver, there's no way to plug goose in.

## Intuition

Thin wrapper over the existing `sparksql.SparkSession`. Each `driver.Conn` holds one session; `ExecContext` forwards to `session.Sql`; `QueryContext` collects the resulting DataFrame into a row-iterator; `BeginTx` returns a no-op. `sql.Register("spark", ...)` in `init()` so `sql.Open("spark", "sc://...")` works on a blank import.

Strict invariant throughout: **zero changes to existing files under `spark/sql/`**. The driver sits in a new sub-package (`spark/sql/driver/`). Diff against upstream `apache/spark-connect-go` master is additions only.

## Usage

```go
import (
    "database/sql"
    _ "github.com/datalakego/spark-connect-go/spark/sql/driver"
)

db, err := sql.Open("spark", "sc://localhost:15002?format=iceberg")
_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS users (id STRING) USING iceberg`)
rows, err := db.QueryContext(ctx, `SELECT id FROM users`)
```

DSN grammar:

```
sc://host:port                            plain
sc://host:port?token=<bearer>             bearer-token auth
sc://host:port?format=iceberg|delta       format passthrough for
                                          dialect-aware consumers
                                          (goose-spark reads this)
```

## Implementation

New package `spark/sql/driver/`, seven files:

| File | What |
|---|---|
| `driver.go` | `sparkDriver` (Driver + DriverContext), `connector` (Connector), `sql.Register("spark", ...)` in init |
| `dsn.go` | `sc://` DSN parser with `format` / `token` query-parameter handling |
| `conn.go` | `conn` (Conn + ConnPrepareContext + ConnBeginTx + ExecerContext + QueryerContext + Pinger); no-op `tx` |
| `stmt.go` | `stmt` (Stmt + StmtExecContext + StmtQueryContext); `errArgsUnsupported` sentinel for v0 arg-rejection |
| `result.go` | `result` with `RowsAffected=-1` and erroring `LastInsertId` |
| `rows.go` | `rows` wraps a collected DataFrame slice; Columns / Close / Next |
| `driver_test.go` | 16 tests covering every exported path |

v0 scope — exactly what goose's Spark dialect needs:

- CREATE / INSERT / SELECT against a Spark Connect endpoint.
- `NumInput() == 0`. Parameter binding isn't wired; callers that pass args see `errArgsUnsupported`. Migrations author literal SQL so this doesn't bite in practice. v1+ maps parameters to Spark Connect's parameterised-query proto.
- No prepared-statement caching; every Exec/Query re-sends the statement. Right-sized for goose's request rate.
- `Rows` wraps a materialised `DataFrame.Collect` slice. Fine for small reads (goose's version-table SELECTs). Larger scans should bypass `database/sql` and use the native DataFrame / `iter.Seq2` path.
- No-op `Tx`: lakehouse commit semantics are per-statement inside the table format (Iceberg snapshot / Delta log). A SQL-layer `Tx` doesn't buy atomicity, so `Commit` succeeds silently and `Rollback` returns a loud error.

## Tests

```
=== RUN   TestParseDSN_AcceptsPlainSc                          PASS
=== RUN   TestParseDSN_ParsesFormatParameter                   PASS
=== RUN   TestParseDSN_NormalisesFormatCase                    PASS
=== RUN   TestParseDSN_RejectsUnknownFormat                    PASS
=== RUN   TestParseDSN_RejectsMissingSchemePrefix              PASS
=== RUN   TestParseDSN_RejectsEmpty                            PASS
=== RUN   TestParseDSN_PreservesTokenInSparkDSN                PASS
=== RUN   TestDriver_RegistersAsSparkOnImport                  PASS
=== RUN   TestDriver_OpenConnectorInvalidDSN                   PASS
=== RUN   TestStmt_ExecContextRejectsArgs                      PASS
=== RUN   TestStmt_QueryContextRejectsArgs                     PASS
=== RUN   TestRows_ColumnsReportsFieldNamesFromFirstRow        PASS
=== RUN   TestRows_ColumnsEmptyOnEmptyResult                   PASS
=== RUN   TestRows_NextWalksResultAndStopsOnEOF                PASS
=== RUN   TestTx_CommitIsNoop                                  PASS
=== RUN   TestTx_RollbackErrors                                PASS
```

End-to-end coverage against a live Spark Connect endpoint lives behind the existing `SPARK_HOME`-gated integration suite; adding a `driver_integration_test.go` there is a follow-up once this package merges.

## Additive invariant (verified)

```
$ git diff main --stat -- spark/sql/
 spark/sql/driver/conn.go        | +164
 spark/sql/driver/driver.go      | +115
 spark/sql/driver/driver_test.go | +250
 spark/sql/driver/dsn.go         |  +80
 spark/sql/driver/result.go      |  +43
 spark/sql/driver/rows.go        |  +76
 spark/sql/driver/stmt.go        | +116
```

Every change is a new file in a new sub-directory. Zero modifications to pre-existing files.