### PR TITLE
feat: parameter binding + drop format DSN param from database/sql driver

### DIFF
--- a/spark/sql/driver/driver_test.go
+++ b/spark/sql/driver/driver_test.go
@@ -16,10 +16,8 @@
 package driver
 
 import (
-	"context"
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -37,36 +35,6 @@ func TestParseDSN_AcceptsPlainSc(t *testing.T) {
 	if cfg.sparkDSN != "sc://localhost:15002" {
 		t.Errorf("sparkDSN = %q", cfg.sparkDSN)
 	}
-	if cfg.format != "" {
-		t.Errorf("format = %q, want empty", cfg.format)
-	}
-}
-
-func TestParseDSN_ParsesFormatParameter(t *testing.T) {
-	cfg, err := parseDSN("sc://localhost:15002?format=iceberg")
-	if err != nil {
-		t.Fatalf("parseDSN: %v", err)
-	}
-	if cfg.format != "iceberg" {
-		t.Errorf("format = %q, want iceberg", cfg.format)
-	}
-}
-
-func TestParseDSN_NormalisesFormatCase(t *testing.T) {
-	cfg, err := parseDSN("sc://localhost:15002?format=DELTA")
-	if err != nil {
-		t.Fatalf("parseDSN: %v", err)
-	}
-	if cfg.format != "delta" {
-		t.Errorf("format = %q, want delta (lowercased)", cfg.format)
-	}
-}
-
-func TestParseDSN_RejectsUnknownFormat(t *testing.T) {
-	_, err := parseDSN("sc://localhost:15002?format=duckdb")
-	if err == nil || !strings.Contains(err.Error(), "unsupported format") {
-		t.Errorf("err = %v, want unsupported-format error", err)
-	}
 }
 
 func TestParseDSN_RejectsMissingSchemePrefix(t *testing.T) {
@@ -83,16 +51,19 @@ func TestParseDSN_RejectsEmpty(t *testing.T) {
 	}
 }
 
-func TestParseDSN_PreservesTokenInSparkDSN(t *testing.T) {
-	// The token parameter is meaningful to the downstream session
-	// builder; the driver itself doesn't interpret it but must not
-	// strip it from the DSN forwarded to NewSessionBuilder().Remote.
-	cfg, err := parseDSN("sc://host:15002?token=secret&format=iceberg")
+func TestParseDSN_PreservesQueryParamsInSparkDSN(t *testing.T) {
+	// The driver does not interpret query parameters — not `token`,
+	// not anything else. Parameters must round-trip unchanged into
+	// sparkDSN so the upstream SparkSessionBuilder.Remote sees them.
+	cfg, err := parseDSN("sc://host:15002?token=secret&user=alice")
 	if err != nil {
 		t.Fatalf("parseDSN: %v", err)
 	}
 	if !strings.Contains(cfg.sparkDSN, "token=secret") {
 		t.Errorf("sparkDSN should carry token unchanged; got %q", cfg.sparkDSN)
+	}
+	if !strings.Contains(cfg.sparkDSN, "user=alice") {
+		t.Errorf("sparkDSN should carry user unchanged; got %q", cfg.sparkDSN)
 	}
 }
 
@@ -121,29 +92,14 @@ func TestDriver_OpenConnectorInvalidDSN(t *testing.T) {
 	}
 }
 
-// --- stmt argument rejection ---------------------------------------
-//
-// v0 doesn't implement parameter binding. Callers that pass args
-// should see the errArgsUnsupported sentinel before any server call
-// fires.
+// Parameter binding coverage lives in render_test.go. Here we only
+// pin that NumInput returns -1 so database/sql passes args through
+// untouched instead of rejecting them up front.
 
-func TestStmt_ExecContextRejectsArgs(t *testing.T) {
-	s := &stmt{conn: &conn{}, query: "SELECT 1"}
-	_, err := s.ExecContext(context.Background(), []driver.NamedValue{
-		{Ordinal: 1, Value: 42},
-	})
-	if err == nil || !errors.Is(err, errArgsUnsupported) {
-		t.Errorf("ExecContext with args err = %v, want errArgsUnsupported", err)
-	}
-}
-
-func TestStmt_QueryContextRejectsArgs(t *testing.T) {
-	s := &stmt{conn: &conn{}, query: "SELECT 1"}
-	_, err := s.QueryContext(context.Background(), []driver.NamedValue{
-		{Ordinal: 1, Value: "x"},
-	})
-	if err == nil || !errors.Is(err, errArgsUnsupported) {
-		t.Errorf("QueryContext with args err = %v, want errArgsUnsupported", err)
+func TestStmt_NumInputIsNegativeOne(t *testing.T) {
+	s := &stmt{}
+	if got := s.NumInput(); got != -1 {
+		t.Errorf("NumInput = %d, want -1 (database/sql should not pre-count args)", got)
 	}
 }
 

--- a/spark/sql/driver/dsn.go
+++ b/spark/sql/driver/dsn.go
@@ -18,40 +18,29 @@ package driver
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 )
 
-// dsnConfig is the parsed DSN. Kept minimal — the Spark Connect
-// session builder wants the original URL verbatim, so the config
-// mostly exists to surface query-parameter knobs (format, token)
-// that downstream tools want to read without re-parsing the DSN.
+// dsnConfig is the parsed DSN. The driver is a boring transport
+// layer — it stays out of table-format concerns (Iceberg vs Delta
+// vs parquet) and keeps the original URL intact for the Spark
+// Connect session builder to interpret.
 type dsnConfig struct {
 	// sparkDSN is what gets passed to NewSessionBuilder().Remote(...).
-	// Includes any `?token=` fragment if present.
+	// Includes any `?token=` or other query fragment verbatim so the
+	// upstream builder sees the URL exactly as the caller wrote it.
 	sparkDSN string
-
-	// format is the value of the `format` query parameter ("iceberg"
-	// / "delta" / empty). Driver ignores it; consumers that need
-	// dialect-aware DDL read it via the exported Connector.Format()
-	// accessor.
-	format string
 }
 
-// parseDSN accepts the sc:// Spark Connect URL form with optional
-// query parameters. Returns an error for malformed input.
+// parseDSN accepts the `sc://host:port[?token=...]` Spark Connect
+// URL form. The driver does not interpret query parameters beyond
+// validating the scheme — any `token`, `user`, or future Spark
+// Connect flag rides through in `sparkDSN` untouched.
 //
-// Recognised query parameters:
-//
-//   - token: bearer token forwarded to the Spark Connect server in
-//     the Authorization header. Preserved in sparkDSN verbatim so
-//     the session builder picks it up.
-//   - format: lakehouse table format ("iceberg" | "delta"). Driver-
-//     layer passthrough; used by consumers like goose-spark to pick
-//     a dialect-appropriate CREATE TABLE.
-//
-// Unrecognised parameters are ignored (preserved in the DSN as-is)
-// so the driver doesn't fight with future Spark Connect flags.
+// Table format selection (Iceberg, Delta, parquet) is explicitly
+// NOT a driver concern. Migrations and application SQL pick format
+// via Spark's native `USING <format>` DDL clause; the transport
+// layer stays boring and reusable.
 func parseDSN(dsn string) (*dsnConfig, error) {
 	if dsn == "" {
 		return nil, errors.New("spark driver: DSN is required")
@@ -59,18 +48,5 @@ func parseDSN(dsn string) (*dsnConfig, error) {
 	if !strings.HasPrefix(dsn, "sc://") {
 		return nil, fmt.Errorf("spark driver: DSN must start with sc://, got %q", dsn)
 	}
-	u, err := url.Parse(dsn)
-	if err != nil {
-		return nil, fmt.Errorf("spark driver: parse DSN: %w", err)
-	}
-
-	cfg := &dsnConfig{
-		sparkDSN: dsn,
-		format:   strings.ToLower(u.Query().Get("format")),
-	}
-	if cfg.format != "" && cfg.format != "iceberg" && cfg.format != "delta" {
-		return nil, fmt.Errorf(
-			"spark driver: unsupported format %q; expected iceberg or delta", cfg.format)
-	}
-	return cfg, nil
+	return &dsnConfig{sparkDSN: dsn}, nil
 }

--- a/spark/sql/driver/render.go
+++ b/spark/sql/driver/render.go
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// render interpolates driver.NamedValue arguments into a query
+// string at `$N` placeholders ($1, $2, ...). Values are quoted as
+// Spark SQL literals on the way through.
+//
+// Spark Connect's parameterised-query proto exists but doesn't
+// round-trip reliably across every Spark version the driver
+// supports. Client-side rendering keeps the driver compatible with
+// the full 3.4+ range and mirrors what the native Spark driver in
+// datalakego/lakeorm already does for the same reason.
+//
+// Accepts `$N` placeholders only. `?` is reserved for a future cycle
+// if a caller asks for it — most database/sql-adjacent codegen
+// (sqlc, goose's own dialects, pgx patterns) emits `$N`, so the
+// narrower set suffices and keeps the renderer simple.
+//
+// Supported types are the stdlib-sql defaults: nil, bool, int64,
+// float64, string, []byte, time.Time. Anything rarer surfaces as an
+// error so the caller tightens their query before seeing a silently
+// mis-interpolated value on the wire.
+func render(query string, args []driver.NamedValue) (string, error) {
+	if len(args) == 0 {
+		return query, nil
+	}
+	byOrdinal := make(map[int]driver.Value, len(args))
+	for _, a := range args {
+		byOrdinal[a.Ordinal] = a.Value
+	}
+
+	var b strings.Builder
+	b.Grow(len(query) + 32)
+	for i := 0; i < len(query); {
+		c := query[i]
+
+		// Pass single-quoted string literals through untouched, so a
+		// `'$1'` in the caller's query stays literal rather than
+		// getting parameter-substituted.
+		if c == '\'' {
+			b.WriteByte(c)
+			i++
+			for i < len(query) {
+				if query[i] == '\'' {
+					// Doubled '' is an escaped quote; keep scanning.
+					if i+1 < len(query) && query[i+1] == '\'' {
+						b.WriteByte('\'')
+						b.WriteByte('\'')
+						i += 2
+						continue
+					}
+					b.WriteByte('\'')
+					i++
+					break
+				}
+				b.WriteByte(query[i])
+				i++
+			}
+			continue
+		}
+
+		if c == '$' && i+1 < len(query) && query[i+1] >= '0' && query[i+1] <= '9' {
+			j := i + 1
+			for j < len(query) && query[j] >= '0' && query[j] <= '9' {
+				j++
+			}
+			ord, _ := strconv.Atoi(query[i+1 : j])
+			v, ok := byOrdinal[ord]
+			if !ok {
+				return "", fmt.Errorf("spark driver: no argument for placeholder $%d", ord)
+			}
+			lit, err := sqlLiteral(v)
+			if err != nil {
+				return "", fmt.Errorf("spark driver: placeholder $%d: %w", ord, err)
+			}
+			b.WriteString(lit)
+			i = j
+			continue
+		}
+
+		b.WriteByte(c)
+		i++
+	}
+	return b.String(), nil
+}
+
+// sqlLiteral renders a single Go value as a Spark SQL literal token.
+// Strings are single-quoted with embedded quotes doubled. Time values
+// render as TIMESTAMP literals in UTC microsecond precision — matches
+// Spark's default timestamp parsing.
+func sqlLiteral(v driver.Value) (string, error) {
+	switch x := v.(type) {
+	case nil:
+		return "NULL", nil
+	case bool:
+		if x {
+			return "TRUE", nil
+		}
+		return "FALSE", nil
+	case int64:
+		return strconv.FormatInt(x, 10), nil
+	case float64:
+		return strconv.FormatFloat(x, 'g', -1, 64), nil
+	case string:
+		return "'" + strings.ReplaceAll(x, "'", "''") + "'", nil
+	case []byte:
+		return "'" + strings.ReplaceAll(string(x), "'", "''") + "'", nil
+	case time.Time:
+		return "TIMESTAMP '" + x.UTC().Format("2006-01-02 15:04:05.000000") + "'", nil
+	default:
+		return "", fmt.Errorf("unsupported arg type %T", v)
+	}
+}

--- a/spark/sql/driver/render_test.go
+++ b/spark/sql/driver/render_test.go
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"database/sql/driver"
+	"strings"
+	"testing"
+	"time"
+)
+
+func namedArgs(vs ...any) []driver.NamedValue {
+	out := make([]driver.NamedValue, len(vs))
+	for i, v := range vs {
+		out[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return out
+}
+
+func TestRender_NoArgsPassesThrough(t *testing.T) {
+	got, err := render("SELECT 1", nil)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if got != "SELECT 1" {
+		t.Errorf("got %q, want unchanged", got)
+	}
+}
+
+func TestRender_Int64AndBool(t *testing.T) {
+	// goose's Insert always passes (version int64, is_applied bool).
+	// Verify the exact shape it emits renders to valid Spark SQL.
+	q := `INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2)`
+	got, err := render(q, namedArgs(int64(20260419000001), true))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	want := `INSERT INTO goose_db_version (version_id, is_applied) VALUES (20260419000001, TRUE)`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRender_StringEscapesEmbeddedQuotes(t *testing.T) {
+	got, err := render(`SELECT * FROM t WHERE name = $1`, namedArgs("O'Brien"))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(got, "'O''Brien'") {
+		t.Errorf("got %q, want doubled-quote escape", got)
+	}
+}
+
+func TestRender_LeavesLiteralInsideStringAlone(t *testing.T) {
+	// A `$1` that lives inside a quoted literal must stay literal.
+	// Otherwise something like `WHERE s = '$1'` would try to
+	// substitute into the user-intended string.
+	got, err := render(`SELECT '$1 then $2' WHERE id = $1`, namedArgs(int64(42)))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(got, "'$1 then $2'") {
+		t.Errorf("got %q, string-literal $-tokens should stay untouched", got)
+	}
+	if !strings.Contains(got, "id = 42") {
+		t.Errorf("got %q, outer $1 should have been replaced with 42", got)
+	}
+}
+
+func TestRender_NilBecomesSQLNull(t *testing.T) {
+	got, err := render(`SELECT $1`, namedArgs(nil))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if got != "SELECT NULL" {
+		t.Errorf("got %q, want SELECT NULL", got)
+	}
+}
+
+func TestRender_TimeRendersAsTimestampLiteral(t *testing.T) {
+	ts := time.Date(2026, 4, 19, 12, 34, 56, 0, time.UTC)
+	got, err := render(`SELECT $1`, namedArgs(ts))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(got, "TIMESTAMP '2026-04-19 12:34:56") {
+		t.Errorf("got %q, want TIMESTAMP literal", got)
+	}
+}
+
+func TestRender_UnsupportedTypeErrors(t *testing.T) {
+	type custom struct{ N int }
+	_, err := render(`SELECT $1`, namedArgs(custom{N: 5}))
+	if err == nil || !strings.Contains(err.Error(), "unsupported arg type") {
+		t.Errorf("err = %v, want unsupported-arg-type", err)
+	}
+}
+
+func TestRender_MissingOrdinalErrors(t *testing.T) {
+	// $3 referenced but only two args supplied — surfaces at render
+	// time rather than on the wire, so the error points at the query.
+	_, err := render(`INSERT INTO t VALUES ($1, $2, $3)`, namedArgs(int64(1), int64(2)))
+	if err == nil || !strings.Contains(err.Error(), "$3") {
+		t.Errorf("err = %v, want missing-ordinal error naming $3", err)
+	}
+}

--- a/spark/sql/driver/stmt.go
+++ b/spark/sql/driver/stmt.go
@@ -18,7 +18,6 @@ package driver
 import (
 	"context"
 	"database/sql/driver"
-	"errors"
 )
 
 // stmt wraps one query string against a conn. The driver doesn't
@@ -40,15 +39,14 @@ type stmt struct {
 // Implements database/sql/driver.Stmt.
 func (*stmt) Close() error { return nil }
 
-// NumInput reports the number of placeholders this statement
-// expects. v0 doesn't support parameter binding, so we return 0
-// and reject non-empty arg slices in ExecContext / QueryContext.
-// goose's generated SQL (CreateVersionTable / InsertVersion) and
-// hand-authored migration files don't use placeholders, so this
-// limitation isn't felt in practice.
+// NumInput reports -1 — "driver doesn't know the number of
+// placeholders." The renderer parses `$N` tokens inline at Exec /
+// Query time, so the sql package's up-front arg-count check doesn't
+// apply. Returning -1 tells database/sql to hand any arg count
+// through unchanged.
 //
 // Implements database/sql/driver.Stmt.
-func (*stmt) NumInput() int { return 0 }
+func (*stmt) NumInput() int { return -1 }
 
 // Exec is the legacy (non-context) Exec entry. Implements
 // database/sql/driver.Stmt.
@@ -75,13 +73,18 @@ func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 // that metric reliably at the session.Sql layer. database/sql
 // allows -1 per the driver.Result docs.
 //
+// Arguments are rendered into the query at $N placeholders before
+// the session call fires; Spark Connect's protocol-level parameter
+// binding doesn't round-trip reliably across every supported Spark
+// version, so client-side rendering is the compatible path.
+//
 // Implements database/sql/driver.StmtExecContext.
 func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	if len(args) > 0 {
-		return nil, errArgsUnsupported
-	}
-	_, err := s.conn.session.Sql(ctx, s.query)
+	q, err := render(s.query, args)
 	if err != nil {
+		return nil, err
+	}
+	if _, err := s.conn.session.Sql(ctx, q); err != nil {
 		return nil, err
 	}
 	return result{}, nil
@@ -93,12 +96,16 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 // fires) this is right-sized; large result sets should bypass the
 // driver and use the native DataFrame / iter.Seq2 path directly.
 //
+// Arguments are rendered into the query at $N placeholders before
+// the session call fires — see ExecContext for rationale.
+//
 // Implements database/sql/driver.StmtQueryContext.
 func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	if len(args) > 0 {
-		return nil, errArgsUnsupported
+	q, err := render(s.query, args)
+	if err != nil {
+		return nil, err
 	}
-	df, err := s.conn.session.Sql(ctx, s.query)
+	df, err := s.conn.session.Sql(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -108,9 +115,3 @@ func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 	}
 	return newRows(rows), nil
 }
-
-// errArgsUnsupported is the v0 signal that parameter binding isn't
-// implemented. Sentinel so callers can errors.Is on it.
-var errArgsUnsupported = errors.New(
-	"spark driver: parameter binding is not supported in v0; interpolate values into the SQL string or upgrade when v1 ships",
-)


### PR DESCRIPTION
## Summary

Two keep-the-driver-boring changes:

### 1. Parameter binding

\`database/sql\`-aware tools (goose, sqlc, pgx consumers) need \`\$N\` placeholder substitution on \`ExecContext\` / \`QueryContext\`. New \`render.go\` walks the query, swaps \`\$N\` for the corresponding \`NamedValue\`, and quotes the literal as Spark SQL. \`NumInput\` now returns \`-1\` so \`database/sql\` passes args through rather than pre-rejecting them.

Spark Connect's protocol-level parameter-binding proto isn't round-trip-stable across every supported Spark version, so client-side rendering is the compatible path — mirrors what the native Spark driver in \`datalakego/lakeorm\` already does for the same reason.

Supported types (the stdlib-sql defaults): \`nil\`, \`bool\`, \`int64\`, \`float64\`, \`string\`, \`[]byte\`, \`time.Time\`. String single-quotes are doubled; \`\$N\` inside a quoted literal stays literal; unknown types surface an error naming the query token rather than silently interpolating garbage.

### 2. Drop the \`?format=iceberg|delta\` DSN parameter

The driver is the transport layer; it should stay out of lakehouse table-format concerns. Migration SQL and application SQL pick Iceberg vs Delta vs Parquet via Spark's native \`USING <format>\` DDL clause, exactly as upstream Spark documents. Consumers that want format-dependent bookkeeping (like goose's version table) select a dialect at that layer, not via the DSN.

## Test plan

- [x] \`go build ./...\` clean
- [x] New \`render_test.go\` covers int64+bool (goose's Insert shape), string-quote escaping, \`\$N\`-inside-literal preservation, NULL/time/bytes rendering, missing-ordinal + unsupported-type errors
- [x] \`driver_test.go\` DSN tests trimmed to match the reverted parse surface
- [x] \`gofumpt\` clean